### PR TITLE
Use fallback hero background by default

### DIFF
--- a/src/components/Hero3D.tsx
+++ b/src/components/Hero3D.tsx
@@ -36,7 +36,10 @@ const StaticIllustration = () => (
 export default function Hero3D() {
   const prefersReducedMotion = usePrefersReducedMotion();
 
-  if (prefersReducedMotion) {
+  const isHero3DEnabled =
+    import.meta.env.VITE_ENABLE_HERO_3D?.toLowerCase() === 'true';
+
+  if (prefersReducedMotion || !isHero3DEnabled) {
     return <StaticIllustration />;
   }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_PUBLIC_SUPABASE_URL: string;
   readonly VITE_PUBLIC_SUPABASE_ANON_KEY: string;
+  readonly VITE_ENABLE_HERO_3D?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- gate the 3D hero background behind a Vite flag and default to the static fallback illustration
- extend the Vite env typings to cover the new hero background toggle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3aef936bc83228d3e937944140d54