### PR TITLE
Ensure navigation remains stable with Google Translate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import { useEffect, lazy, Suspense } from "react";
+import NavigationInterceptor from "./components/NavigationInterceptor";
 import {
   detectInitialLanguage,
   initializeGoogleTranslate,
@@ -47,6 +48,7 @@ const App = () => {
         <Toaster />
         <Sonner />
         <BrowserRouter>
+          <NavigationInterceptor />
           <Navbar />
           <Suspense
             fallback={

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,7 +24,7 @@ export default function Navbar() {
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <nav className="fixed left-1/2 top-4 z-50 w-full -translate-x-1/2 px-4 sm:px-6">
+    <nav className="notranslate fixed left-1/2 top-4 z-50 w-full -translate-x-1/2 px-4 sm:px-6">
       <div className="mx-auto flex max-w-6xl items-center justify-between rounded-full border border-border/60 bg-card/70 px-4 py-3 shadow-[0_20px_45px_-25px_rgba(56,189,248,0.55)] backdrop-blur-xl">
         <Link
           to="/"

--- a/src/components/NavigationInterceptor.tsx
+++ b/src/components/NavigationInterceptor.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+const isModifiedEvent = (event: MouseEvent) =>
+  event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+
+const isExternalUrl = (href: string) => {
+  if (href.startsWith("mailto:")) return true;
+  if (href.startsWith("tel:")) return true;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) return true;
+  if (href.startsWith("//")) return true;
+  return false;
+};
+
+export const NavigationInterceptor = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.button !== 0) return;
+      if (isModifiedEvent(event)) return;
+
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest?.("a");
+      if (!anchor) return;
+
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+      if (anchor.target && anchor.target !== "_self") return;
+      if (href.startsWith("#")) return;
+      if (isExternalUrl(href)) return;
+
+      event.preventDefault();
+      const url = new URL(href, window.location.origin);
+      const nextPath = `${url.pathname}${url.search}${url.hash}`;
+      navigate(nextPath);
+    };
+
+    document.addEventListener("click", handleClick, true);
+    return () => {
+      document.removeEventListener("click", handleClick, true);
+    };
+  }, [navigate]);
+
+  return null;
+};
+
+export default NavigationInterceptor;


### PR DESCRIPTION
## Summary
- add a document-level navigation interceptor so SPA routing still works even if Google Translate rewrites anchor tags
- flag the navbar as `notranslate` to discourage the widget from mutating navigation markup

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e501d309188322b2bae388e73ea984