### PR TITLE
Refactor animated links to use motion wrappers

### DIFF
--- a/src/components/ArtworkCard.tsx
+++ b/src/components/ArtworkCard.tsx
@@ -3,6 +3,8 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { ExternalLink } from 'lucide-react';
 import React from 'react';
 
+const MotionLink = motion(Link);
+
 interface ArtworkCardProps {
   artwork: {
     slug: string;
@@ -27,7 +29,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({ artwork, index }) => {
       className="group"
     >
       <div className="rounded-[var(--radius)] border border-border/70 bg-card overflow-hidden shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-[0_35px_60px_-45px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
-        <Link
+        <MotionLink
           to={`/art/${artwork.slug}`}
           className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           style={{ transformStyle: 'preserve-3d' }}
@@ -83,7 +85,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({ artwork, index }) => {
               ))}
             </div>
           </div>
-        </Link>
+        </MotionLink>
         {artwork.url3d && (
           <div className="p-6 pt-0">
             <a

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,8 @@ import { Github, Linkedin, Mail } from 'lucide-react';
 import { motion, useReducedMotion } from 'framer-motion';
 import cvData from '../../public/data/cv.json';
 
+const MotionLink = motion(Link);
+
 export default function Footer() {
   const prefersReducedMotion = useReducedMotion();
 
@@ -41,7 +43,7 @@ export default function Footer() {
         <div className="flex flex-col md:flex-row items-center justify-between gap-8">
           {/* Logo and Copyright */}
           <div className="flex flex-col items-center md:items-start text-center md:text-left">
-            <Link
+            <MotionLink
               to="/"
               className="flex items-center gap-2 rounded-full px-3 py-1 text-sm font-semibold text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               whileHover={prefersReducedMotion ? undefined : { scale: 1.05, boxShadow: '0 0 15px rgba(var(--primary-hsl)/0.3)' }}
@@ -54,7 +56,7 @@ export default function Footer() {
               <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
                 {cvData.profile.name.split(' ')[0]}
               </span>
-            </Link>
+            </MotionLink>
             <p className="mt-4 text-sm text-muted-foreground">
               &copy; {new Date().getFullYear()} Monynha Softwares. Todos os direitos reservados.
             </p>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -3,6 +3,8 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { ExternalLink, Code2 } from 'lucide-react';
 import React from 'react';
 
+const MotionLink = motion(Link);
+
 interface ProjectCardProps {
   project: {
     slug: string;
@@ -28,7 +30,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
       className="group"
     >
       <div className="rounded-[var(--radius)] border border-border/70 bg-card overflow-hidden shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-[0_35px_60px_-45px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
-        <Link
+        <MotionLink
           to={`/portfolio/${project.slug}`}
           className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           style={{ transformStyle: 'preserve-3d' }}
@@ -84,7 +86,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
               ))}
             </div>
           </div>
-        </Link>
+        </MotionLink>
         <div className="p-6 pt-0">
           <a
             href={project.url}

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -3,6 +3,8 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { ExternalLink, Layers } from 'lucide-react';
 import React from 'react';
 
+const MotionLink = motion(Link);
+
 interface SeriesCardProps {
   series: {
     slug: string;
@@ -25,7 +27,7 @@ const SeriesCard: React.FC<SeriesCardProps> = ({ series, index }) => {
       className="group"
     >
       <div className="rounded-[var(--radius)] border border-border/70 bg-card overflow-hidden shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-[0_35px_60px_-45px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
-        <Link
+        <MotionLink
           to={`/series/${series.slug}`}
           className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           style={{ transformStyle: 'preserve-3d' }}
@@ -68,7 +70,7 @@ const SeriesCard: React.FC<SeriesCardProps> = ({ series, index }) => {
               )}
             </div>
           </div>
-        </Link>
+        </MotionLink>
         <div className="p-6 pt-0">
           <Link
             to={`/series/${series.slug}`}


### PR DESCRIPTION
## Summary
- wrap animated router links in motion-enhanced components to avoid leaking animation props
- ensure footer brand, project, artwork, and series cards retain focus styles while using motion links

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ee38feb1848322b875fb501df0137e