### PR TITLE
Fix motion props on detail page buttons

### DIFF
--- a/src/pages/ArtDetail.tsx
+++ b/src/pages/ArtDetail.tsx
@@ -16,6 +16,8 @@ import {
   useCurrentLanguage,
 } from '@/hooks/useCurrentLanguage';
 
+const MotionButton = motion(Button);
+
 const isArtPreview3DEnabled =
   import.meta.env.VITE_ENABLE_ART_3D?.toLowerCase() === 'true';
 
@@ -65,7 +67,7 @@ export default function ArtDetail() {
           transition={{ duration: 0.6 }}
           className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_90px_-70px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
         >
-          <Button
+          <MotionButton
             asChild
             variant="ghost"
             className="mb-8 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
@@ -77,7 +79,7 @@ export default function ArtDetail() {
               <ArrowLeft className="h-4 w-4" aria-hidden />
               Voltar ao Portfolio
             </Link>
-          </Button>
+          </MotionButton>
 
           <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
             <motion.span
@@ -142,7 +144,7 @@ export default function ArtDetail() {
 
           {artwork.url3d && (
             <div className="mt-10 flex flex-wrap items-center gap-4">
-              <Button
+              <MotionButton
                 type="button"
                 onClick={() => setIs3DOpen(true)}
                 className="inline-flex items-center gap-2 rounded-full"
@@ -153,7 +155,7 @@ export default function ArtDetail() {
               >
                 <Orbit className="h-4 w-4" aria-hidden />
                 {canRender3DPreview ? 'Explorar Experiência 3D' : 'Pré-visualização Indisponível'}
-              </Button>
+              </MotionButton>
               <motion.a
                 href={artwork.url3d}
                 target="_blank"

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -9,6 +9,8 @@ import {
   useCurrentLanguage,
 } from '@/hooks/useCurrentLanguage';
 
+const MotionButton = motion(Button);
+
 export default function ProjectDetail() {
   const { slug } = useParams<{ slug: string }>();
   const prefersReducedMotion = useReducedMotion();
@@ -61,7 +63,7 @@ export default function ProjectDetail() {
           className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_90px_-70px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
         >
           <motion.div variants={itemVariants}>
-            <Button
+            <MotionButton
               asChild
               variant="ghost"
               className="mb-8 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
@@ -73,7 +75,7 @@ export default function ProjectDetail() {
                 <ArrowLeft className="h-4 w-4" aria-hidden />
                 Voltar ao Portfolio
               </Link>
-            </Button>
+            </MotionButton>
           </motion.div>
 
           {/* Overview Section */}

--- a/src/pages/SeriesDetail.tsx
+++ b/src/pages/SeriesDetail.tsx
@@ -8,6 +8,8 @@ import {
   useCurrentLanguage,
 } from '@/hooks/useCurrentLanguage';
 
+const MotionButton = motion(Button);
+
 type WorkCard = {
   slug: string;
   title: string;
@@ -102,7 +104,7 @@ export default function SeriesDetail() {
           transition={{ duration: 0.6 }}
           className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_85px_-70px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
         >
-          <Button
+          <MotionButton
             asChild
             variant="ghost"
             className="mb-8 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
@@ -114,7 +116,7 @@ export default function SeriesDetail() {
               <ArrowLeft className="h-4 w-4" aria-hidden />
               Voltar ao Portfolio
             </Link>
-          </Button>
+          </MotionButton>
 
           <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
             <motion.span

--- a/src/pages/ThoughtDetail.tsx
+++ b/src/pages/ThoughtDetail.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/hooks/useCurrentLanguage';
 import { calculateReadingTime } from '@/lib/content';
 
+const MotionButton = motion(Button);
+
 export default function ThoughtDetail() {
   const { slug } = useParams<{ slug: string }>();
   const prefersReducedMotion = useReducedMotion();
@@ -49,7 +51,7 @@ export default function ThoughtDetail() {
           transition={{ duration: 0.6 }}
           className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-8 shadow-[0_45px_85px_-70px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
         >
-          <Button
+          <MotionButton
             asChild
             variant="ghost"
             className="mb-6 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
@@ -61,7 +63,7 @@ export default function ThoughtDetail() {
               <ArrowLeft className="h-4 w-4" aria-hidden />
               Voltar para os Pensamentos
             </Link>
-          </Button>
+          </MotionButton>
 
           <div className="flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
             <motion.span


### PR DESCRIPTION
## Summary
- add a reusable MotionButton helper to each detail page so Framer Motion hover/tap props stay on a motion-aware component
- update the animated navigation and action buttons to use the helper, keeping their existing styling and accessibility props intact

## Testing
- pnpm lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ee3b0ed2f4832299def384713449fa