### PR TITLE
Use motion image for art previews

### DIFF
--- a/src/pages/ArtDetail.tsx
+++ b/src/pages/ArtDetail.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/hooks/useCurrentLanguage';
 
 const MotionButton = motion(Button);
+const MotionImg = motion.img;
 
 const isArtPreview3DEnabled =
   import.meta.env.VITE_ENABLE_ART_3D?.toLowerCase() === 'true';
@@ -121,7 +122,7 @@ export default function ArtDetail() {
                 whileHover={prefersReducedMotion ? undefined : { scale: 1.02 }}
                 whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
               >
-                <img
+                <MotionImg
                   src={media}
                   alt={`${artwork.title} — visual ${index + 1}`}
                   loading="lazy"


### PR DESCRIPTION
## Summary
- convert art detail media previews to use a MotionImg component so hover animations are handled by Framer Motion
- keep accessibility and performance-related img attributes intact while preventing React unknown prop warnings

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee407fd9f08322acce59e7fb7ddcf5