### PR TITLE
Fix depth cue shadows to use HSL tokens

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -46,11 +46,15 @@ export default function Footer() {
             <MotionLink
               to="/"
               className="flex items-center gap-2 rounded-full px-3 py-1 text-sm font-semibold text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-              whileHover={prefersReducedMotion ? undefined : { scale: 1.05, boxShadow: '0 0 15px rgba(var(--primary-hsl)/0.3)' }}
+              whileHover={
+                prefersReducedMotion
+                  ? undefined
+                  : { scale: 1.05, boxShadow: '0 0 15px hsl(var(--primary) / 0.3)' }
+              }
               whileTap={prefersReducedMotion ? undefined : { scale: 0.95 }}
               transition={{ type: 'spring', stiffness: 300, damping: 20 }}
             >
-              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-primary to-secondary font-display text-base text-white shadow-[0_0_12px_rgba(var(--secondary-hsl)/0.2)]">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-primary to-secondary font-display text-base text-white shadow-[0_0_12px_hsl(var(--secondary)/0.2)]">
                 M
               </span>
               <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -38,12 +38,14 @@ export default function Navbar() {
         initial={shouldReduceMotion ? undefined : { y: -100, opacity: 0 }}
         animate={shouldReduceMotion ? undefined : { y: 0, opacity: 1 }}
         transition={{ type: 'spring', stiffness: 120, damping: 15, delay: 0.1 }}
-        className="mx-auto flex max-w-6xl items-center justify-between rounded-full border border-border/60 bg-card/80 px-6 py-3 shadow-[0_20px_45px_-25px_rgba(var(--primary-hsl)/0.2)] backdrop-blur-xl"
+        className="mx-auto flex max-w-6xl items-center justify-between rounded-full border border-border/60 bg-card/80 px-6 py-3 shadow-[0_20px_45px_-25px_hsl(var(--primary)/0.2)] backdrop-blur-xl"
       >
         <MotionLink
           to="/"
           className="flex items-center gap-2 rounded-full px-3 py-1 text-sm font-semibold text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          whileHover={shouldReduceMotion ? undefined : { scale: 1.05, boxShadow: '0 0 15px rgba(var(--primary-hsl)/0.3)' }}
+          whileHover={
+            shouldReduceMotion ? undefined : { scale: 1.05, boxShadow: '0 0 15px hsl(var(--primary) / 0.3)' }
+          }
           whileTap={shouldReduceMotion ? undefined : { scale: 0.95 }}
           transition={{ type: 'spring', stiffness: 300, damping: 20 }}
         >
@@ -74,7 +76,7 @@ export default function Navbar() {
                         whileHover: {
                           y: -2,
                           boxShadow:
-                            '0 12px 24px -18px rgba(var(--secondary-hsl)/0.3), 0 0 12px rgba(var(--primary-hsl)/0.2)',
+                            '0 12px 24px -18px hsl(var(--secondary) / 0.3), 0 0 12px hsl(var(--primary) / 0.2)',
                         },
                       }
                     : {})}

--- a/src/index.css
+++ b/src/index.css
@@ -19,15 +19,18 @@ All colors MUST be HSL.
 
     --primary: 240 60% 40%; /* Deep Indigo */
     --primary-foreground: 0 0% 98%; /* White for text on primary buttons */
+    --primary-hsl: 240 60% 40%;
 
     --secondary: 210 70% 50%; /* Vibrant Sky Blue */
     --secondary-foreground: 0 0% 98%;
+    --secondary-hsl: 210 70% 50%;
 
     --muted: 220 10% 25%; /* Medium dark gray for muted backgrounds */
     --muted-foreground: 220 10% 70%; /* Light gray for muted text */
 
     --accent: 270 40% 60%; /* Soft Lavender Purple */
     --accent-foreground: 0 0% 98%;
+    --accent-hsl: 270 40% 60%;
 
     --destructive: 0 63% 31%; /* Keep vibrant red */
     --destructive-foreground: 0 0% 98%;

--- a/src/pages/ArtDetail.tsx
+++ b/src/pages/ArtDetail.tsx
@@ -66,7 +66,7 @@ export default function ArtDetail() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_90px_-70px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
+          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_90px_-70px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
         >
           <MotionButton
             asChild

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,7 @@ export default function Home() {
           >
             <motion.div
               variants={itemVariants}
-              className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/60 px-4 py-2 shadow-[0_20px_35px_-25px_rgba(var(--secondary-hsl)/0.2)]"
+              className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/60 px-4 py-2 shadow-[0_20px_35px_-25px_hsl(var(--secondary)/0.2)]"
             >
               <Sparkles className="w-4 h-4 text-accent" />
               <span className="text-sm font-medium">{cvData.profile.location}</span>
@@ -71,7 +71,7 @@ export default function Home() {
               <Button
                 asChild
                 size="lg"
-                className="rounded-full text-lg px-8 py-6 shadow-[0_15px_45px_-20px_rgba(var(--secondary-hsl)/0.4)]"
+                className="rounded-full text-lg px-8 py-6 shadow-[0_15px_45px_-20px_hsl(var(--secondary)/0.4)]"
               >
                 <Link to="/portfolio">
                   <Code2 className="mr-2" />
@@ -103,7 +103,7 @@ export default function Home() {
                 <PenSquare className="h-4 w-4 text-secondary" aria-hidden />
                 <span>Nova rota: reflexões em tecnologia e arte</span>
               </motion.div>
-              <Button asChild className="rounded-full bg-gradient-to-r from-secondary/70 to-primary/70 px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_30px_-24px_rgba(var(--secondary-hsl)/0.75)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:brightness-105">
+              <Button asChild className="rounded-full bg-gradient-to-r from-secondary/70 to-primary/70 px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_30px_-24px_hsl(var(--secondary)/0.75)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:brightness-105">
                 <Link to="/thoughts">
                   Ler os pensamentos recentes
                   <ArrowRight className="h-4 w-4" aria-hidden />
@@ -178,7 +178,7 @@ export default function Home() {
                 >
                   <div className="rounded-[var(--radius)] border border-border/70 bg-card/60 p-6 shadow-[0_15px_30px_-20px_hsl(var(--primary)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_50px_-25px_hsl(var(--primary)/0.3),_0_10px_20px_-10px_hsl(var(--secondary)/0.2)]">
                     <div className="flex items-start justify-between mb-4">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary/80 via-secondary/70 to-accent/70 text-white shadow-[0_0_20px_rgba(var(--primary-hsl)/0.2)]">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary/80 via-secondary/70 to-accent/70 text-white shadow-[0_0_20px_hsl(var(--primary)/0.2)]">
                         <Code2 className="text-white" size={24} aria-hidden />
                       </div>
                       <span className="text-xs font-medium px-3 py-1 rounded-full bg-muted text-muted-foreground">
@@ -257,7 +257,7 @@ export default function Home() {
                 className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
                 <div className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/70 p-6 shadow-[0_20px_40px_-30px_hsl(var(--secondary)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_30px_60px_-40px_hsl(var(--secondary)/0.3),_0_15px_30px_-15px_hsl(var(--accent)/0.2)]">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-secondary via-primary to-accent text-white shadow-[0_0_20px_rgba(var(--primary-hsl)/0.2)]">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-secondary via-primary to-accent text-white shadow-[0_0_20px_hsl(var(--primary)/0.2)]">
                     <Layers aria-hidden className="h-6 w-6" />
                   </div>
                   <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
@@ -281,7 +281,7 @@ export default function Home() {
                 className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
                 <div className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/70 p-6 shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_30px_60px_-40px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-[0_0_20px_rgba(var(--secondary-hsl)/0.2)]">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-[0_0_20px_hsl(var(--secondary)/0.2)]">
                     <Palette aria-hidden className="h-6 w-6" />
                   </div>
                   <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -20,7 +20,7 @@ const NotFound = () => {
         initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
         animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
-        className="w-full max-w-xl rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 text-center shadow-[0_45px_85px_-70px_rgba(var(--secondary-hsl)/0.3)] backdrop-blur-xl"
+        className="w-full max-w-xl rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 text-center shadow-[0_45px_85px_-70px_hsl(var(--secondary)/0.3)] backdrop-blur-xl"
         role="alert"
         aria-live="assertive"
       >

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -115,7 +115,7 @@ export default function ProjectDetail() {
           variants={containerVariants}
           initial={prefersReducedMotion ? undefined : 'hidden'}
           animate={prefersReducedMotion ? undefined : 'visible'}
-          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_90px_-70px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
+          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_90px_-70px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
         >
           <motion.div variants={itemVariants}>
             <MotionButton

--- a/src/pages/SeriesDetail.tsx
+++ b/src/pages/SeriesDetail.tsx
@@ -102,7 +102,7 @@ export default function SeriesDetail() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_85px_-70px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
+          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_85px_-70px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
         >
           <MotionButton
             asChild
@@ -150,7 +150,7 @@ export default function SeriesDetail() {
             {works.map((work, index) => {
               const card = (
                 <motion.div
-                  className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/80 p-6 shadow-[0_35px_70px_-55px_rgba(var(--secondary-hsl)/0.3)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_55px_-35px_rgba(var(--primary-hsl)/0.3)]"
+                  className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/80 p-6 shadow-[0_35px_70px_-55px_hsl(var(--secondary)/0.3)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_55px_-35px_hsl(var(--primary)/0.3)]"
                   whileHover={prefersReducedMotion ? undefined : { y: -5, boxShadow: '0 10px 20px rgba(0,0,0,0.2)' }}
                 >
                   {work.thumbnail && (

--- a/src/pages/ThoughtDetail.tsx
+++ b/src/pages/ThoughtDetail.tsx
@@ -49,7 +49,7 @@ export default function ThoughtDetail() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-8 shadow-[0_45px_85px_-70px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
+          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-8 shadow-[0_45px_85px_-70px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
         >
           <MotionButton
             asChild

--- a/src/pages/Thoughts.tsx
+++ b/src/pages/Thoughts.tsx
@@ -60,7 +60,7 @@ export default function Thoughts() {
                   animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
                   transition={{ delay: index * 0.1, duration: 0.45 }}
                   whileHover={prefersReducedMotion ? undefined : { y: -5, boxShadow: '0 10px 20px rgba(0,0,0,0.2)' }}
-                  className="group flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/80 p-8 shadow-[0_35px_65px_-55px_rgba(var(--primary-hsl)/0.3)] backdrop-blur-xl"
+                  className="group flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/80 p-8 shadow-[0_35px_65px_-55px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
                 >
                   <div className="mb-6 flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                     <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
@@ -107,7 +107,7 @@ export default function Thoughts() {
             })}
           </div>
 
-          <div className="mt-16 flex flex-col items-center gap-4 rounded-[var(--radius)] border border-border/60 bg-background/40 p-8 text-center shadow-[0_35px_70px_-60px_rgba(var(--secondary-hsl)/0.3)]">
+          <div className="mt-16 flex flex-col items-center gap-4 rounded-[var(--radius)] border border-border/60 bg-background/40 p-8 text-center shadow-[0_35px_70px_-60px_hsl(var(--secondary)/0.3)]">
             <p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Monynha Softwares Journal</p>
             <p className="text-2xl font-display font-semibold text-foreground">
               Ideias, processos criativos e bastidores das experiências imersivas.


### PR DESCRIPTION
## Summary
- add dedicated --*-hsl tokens so primary, secondary, and accent colors can be reused in alpha-aware contexts
- replace rgba(var(--*-hsl)/…) usage across navigation, hero, and detail card components with hsl(var(--token)/α) equivalents
- align glow/shadow effects on CTA buttons and badges with the updated HSL tokens for consistent depth cues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4d077c994832295cb409a209db3dc