### PR TITLE
style: align visual tokens with brand

### DIFF
--- a/audit-report.md
+++ b/audit-report.md
@@ -1,26 +1,44 @@
-# Monynha Portfolio Code Audit Report
+# Auditoria Visual — Marcelo Portigolio
 
-## Código e Organização
-- Remoção do módulo `src/lib/supabase.ts`, que estava obsoleto e não era referenciado no aplicativo.
-- Tipagens aprimoradas nos componentes de UI (`command` e `textarea`) para eliminar interfaces vazias e evitar uso de `any`.
-- Remoção da dependência do Google Translate com a introdução do helper local (`src/lib/language.ts`) para sincronizar o atributo `lang` e eventos de idioma de forma tipada.
+## Sumário
+- Erros encontrados
+  - Paleta só oferecia o modo escuro e os tokens usavam valores inconsistentes com a identidade visual.
+  - Cartões e botões tinham `border-radius` e sombras fora do padrão (`rounded-2xl`, `shadow-md`).
+  - Conteúdos próximos da barra fixa ficavam ocultos e havia contrastes insuficientes no modo claro inexistente.
+- Correções aplicadas
+  - Definição completa dos tokens claros/escuros, normalização das utilitárias (`glass`) e script de detecção de tema.
+  - Ajuste das variantes do `Button`, `Card` e dos cartões principais para usar `rounded-2xl` + `shadow-md/hover:shadow-lg`.
+  - Revisão de seções (Home, Thought/Series/Project detail) com novos espaçamentos e bordas padronizadas.
+- Prints de antes/depois
+  - Hero (modo claro ausente) → Hero com tema claro.
+  - Grade de projetos encoberta pela navbar → grade com espaçamento.
+  - Layout mobile sem tokens de luz → layout mobile coerente.
 
-## Experiência do Usuário & Visual
-- Hero estático atualizado com gradações em HSL, alinhando os visuais aos tons oficiais (#7C3AED, #0EA5E9, #EC4899).
-- Tailwind configurado com famílias `Inter`, `Space Grotesk` e agora `JetBrains Mono`, garantindo consistência tipográfica.
-- Fonte JetBrains carregada no `index.html` para seções de código e detalhes técnicos.
-- Cartões de séries harmonizados (`SeriesDetail`) com semântica de links clara para rotas internas e externas.
-- Pré-visualização 3D das artes agora respeita uma flag `VITE_ENABLE_ART_3D`, evitando carregar bibliotecas pesadas quando o recurso estiver desativado.
+## Prints e Descrições
 
-## Formulários e Integrações
-- Formulário de contato passa a reutilizar um estado inicial imutável e atualizações funcionais de estado, evitando condições de corrida.
-- Logs de Supabase agora aparecem apenas em ambiente de desenvolvimento, mantendo o console limpo em produção.
-- Tratamento de erros no formulário de contato mantém registro apenas em modo desenvolvimento.
+### Tema Claro ausente
+- **Antes:** hero apenas em modo escuro, impossibilitando contraste adequado no tema claro.
+  ![Hero antes](browser:/invocations/hlbjqkxc/artifacts/artifacts/desktop-light.png)
+- **Depois:** tokens claros definidos e script de detecção automática habilitando o modo claro consistente.
+  ![Hero depois](browser:/invocations/siphvrlo/artifacts/artifacts/after-desktop-light.png)
+- **Ajuste:** novos valores HSL no `:root`/`.dark`, tipografia `font-sans` global e utilitário `glass` com `rounded-2xl` + `shadow-md`.
 
-## Acessibilidade e Performance
-- Links de cartões no portfólio usam componentes adequados (`Link` ou `<a>`) com foco visível, melhorando navegação por teclado.
-- Imagens de cards continuam com `loading="lazy"` e atributos alt descritivos.
+### Navegação encobrindo a lista de projetos
+- **Antes:** o heading "Projetos em Destaque" ficava sob a navbar fixa e os cards não seguiam o raio/sombra padrão.
+  ![Projetos antes](browser:/invocations/yggzwzet/artifacts/artifacts/desktop-light-mid.png)
+- **Depois:** seções com `pt-32`/`pt-12`, cartões `rounded-2xl` e sombras padronizadas.
+  ![Projetos depois](browser:/invocations/sejnlmfh/artifacts/artifacts/after-desktop-light-projects.png)
+- **Ajuste:** revisão de `Home.tsx`, `ProjectCard.tsx` e utilitário `glass` para harmonizar tokens.
 
-## Validações
-- `npm run lint` executado para garantir que não há erros de lint.
-- `npm run build` executado para validar o empacotamento de produção e monitorar o tamanho dos bundles.
+### Layout mobile sem tokens de luz
+- **Antes:** versão mobile herdava apenas o modo escuro, com botões e cards usando sombras customizadas.
+  ![Mobile antes](browser:/invocations/yhybubag/artifacts/artifacts/mobile-light.png)
+- **Depois:** tema claro aplicado com botões `rounded-2xl` e cards consistentes.
+  ![Mobile depois](browser:/invocations/grwpgmiv/artifacts/artifacts/after-mobile-light.png)
+- **Ajuste:** atualização de `button.tsx`, `card.tsx` e cartões específicos para reforçar tokens globais.
+
+## Checklist de Conformidade
+✅ Paleta e tokens  
+✅ Tipografia  
+✅ Acessibilidade  
+✅ Layout responsivo

--- a/index.html
+++ b/index.html
@@ -23,6 +23,25 @@
     <meta name="twitter:title" content="Marcelo Santos - Portfolio" />
     <meta name="twitter:description" content="Software Engineer & Founder @ Monynha Softwares" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <script>
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+      const applyTheme = (isDark) => {
+        document.documentElement.classList.toggle('dark', isDark);
+        document.documentElement.dataset.theme = isDark ? 'dark' : 'light';
+        document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+        window.dispatchEvent(new Event('themechange'));
+      };
+
+      applyTheme(mediaQuery.matches);
+
+      const handleChange = (event) => applyTheme(event.matches);
+      if (typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', handleChange);
+      } else if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(handleChange);
+      }
+    </script>
   </head>
 
   <body>

--- a/src/components/ArtworkCard.tsx
+++ b/src/components/ArtworkCard.tsx
@@ -28,7 +28,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({ artwork, index }) => {
       transition={{ delay: index * 0.08, duration: 0.4 }}
       className="group"
     >
-      <div className="rounded-[var(--radius)] border border-border/70 bg-card overflow-hidden shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-[0_35px_60px_-45px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
+      <div className="rounded-2xl border border-border/60 bg-card overflow-hidden shadow-md transition-all focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:-translate-y-1 group-hover:shadow-lg">
         <MotionLink
           to={`/art/${artwork.slug}`}
           className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -38,7 +38,7 @@ export default function Navbar() {
         initial={shouldReduceMotion ? undefined : { y: -100, opacity: 0 }}
         animate={shouldReduceMotion ? undefined : { y: 0, opacity: 1 }}
         transition={{ type: 'spring', stiffness: 120, damping: 15, delay: 0.1 }}
-        className="mx-auto flex max-w-6xl items-center justify-between rounded-full border border-border/60 bg-card/80 px-6 py-3 shadow-[0_20px_45px_-25px_hsl(var(--primary)/0.2)] backdrop-blur-xl"
+        className="mx-auto flex max-w-6xl items-center justify-between rounded-full border border-border/60 bg-card/80 px-6 py-3 shadow-md backdrop-blur-xl"
       >
         <MotionLink
           to="/"

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -49,7 +49,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
       initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
       animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
       transition={{ delay: index * 0.08, duration: 0.45 }}
-      className="group h-full overflow-hidden border-border/70 bg-card/80 shadow-[0_22px_48px_-32px_hsl(var(--primary)_/_0.35)] backdrop-blur"
+      className="group h-full overflow-hidden border border-border/60 bg-card/80 shadow-md backdrop-blur transition-all hover:shadow-lg"
     >
       <div className="relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br from-primary/25 via-secondary/20 to-accent/25">
         <motion.img

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -26,7 +26,7 @@ const SeriesCard: React.FC<SeriesCardProps> = ({ series, index }) => {
       transition={{ delay: index * 0.08, duration: 0.4 }}
       className="group"
     >
-      <div className="rounded-[var(--radius)] border border-border/70 bg-card overflow-hidden shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-[0_35px_60px_-45px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
+      <div className="rounded-2xl border border-border/60 bg-card overflow-hidden shadow-md transition-all focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:-translate-y-1 group-hover:shadow-lg">
         <MotionLink
           to={`/series/${series.slug}`}
           className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,11 +5,11 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-2xl text-sm font-medium shadow-md ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-gradient-to-r from-primary to-secondary text-primary-foreground shadow-lg hover:brightness-110", // Gradient for default
+        default: "bg-gradient-to-r from-primary to-secondary text-primary-foreground hover:brightness-110 hover:shadow-lg", // Gradient for default
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
@@ -20,9 +20,9 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        default: "h-11 px-5",
+        sm: "h-10 px-4 text-sm",
+        lg: "h-12 px-8 text-base",
         icon: "h-10 w-10",
       },
     },

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  <div ref={ref} className={cn("rounded-2xl border bg-card text-card-foreground shadow-md", className)} {...props} />
 ));
 Card.displayName = "Card";
 

--- a/src/index.css
+++ b/src/index.css
@@ -8,49 +8,90 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    --background: 220 10% 8%; /* Very dark gray, almost black */
-    --foreground: 0 0% 98%; /* White for text */
+    color-scheme: light;
+    --background: 220 35% 97%;
+    --foreground: 224 71% 4%;
 
-    --card: 220 10% 12%; /* Slightly lighter dark gray for card backgrounds */
-    --card-foreground: 0 0% 98%;
+    --card: 0 0% 100%;
+    --card-foreground: 224 71% 4%;
 
-    --popover: 220 10% 12%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 224 71% 4%;
 
-    --primary: 240 60% 40%; /* Deep Indigo */
-    --primary-foreground: 0 0% 98%; /* White for text on primary buttons */
-    --primary-hsl: 240 60% 40%;
+    --primary: 240 62% 45%;
+    --primary-foreground: 210 40% 98%;
+    --primary-hsl: 240 62% 45%;
 
-    --secondary: 210 70% 50%; /* Vibrant Sky Blue */
-    --secondary-foreground: 0 0% 98%;
+    --secondary: 210 70% 50%;
+    --secondary-foreground: 0 0% 100%;
     --secondary-hsl: 210 70% 50%;
 
-    --muted: 220 10% 25%; /* Medium dark gray for muted backgrounds */
-    --muted-foreground: 220 10% 70%; /* Light gray for muted text */
+    --muted: 220 20% 92%;
+    --muted-foreground: 220 12% 40%;
 
-    --accent: 270 40% 60%; /* Soft Lavender Purple */
-    --accent-foreground: 0 0% 98%;
-    --accent-hsl: 270 40% 60%;
+    --accent: 270 45% 55%;
+    --accent-foreground: 0 0% 100%;
+    --accent-hsl: 270 45% 55%;
 
-    --destructive: 0 63% 31%; /* Keep vibrant red */
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 0 63% 35%;
+    --destructive-foreground: 210 40% 98%;
 
-    --border: 220 10% 20%; /* Subtle dark gray border */
-    --input: 220 10% 12%; /* Dark input background */
-    --ring: 210 70% 50%; /* Secondary blue for focus ring */
+    --border: 220 18% 88%;
+    --input: 220 18% 88%;
+    --ring: 210 70% 50%;
 
-    --radius: 1.5rem; /* Increased border radius for softer, polished look */
+    --radius: 1rem;
 
     /* Custom tokens */
-    --hero-gradient-start: 240 60% 40%;
+    --hero-gradient-start: 240 62% 45%;
     --hero-gradient-end: 210 70% 50%;
-    --glow-purple: 240 60% 40%;
+    --glow-purple: 240 62% 45%;
     --glow-blue: 210 70% 50%;
-    --glow-pink: 270 40% 60%;
-    
+    --glow-pink: 270 45% 55%;
+
     /* Animations */
     --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     --transition-bounce: all 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  }
+
+  .dark {
+    color-scheme: dark;
+    --background: 220 12% 8%;
+    --foreground: 0 0% 98%;
+
+    --card: 220 12% 12%;
+    --card-foreground: 0 0% 98%;
+
+    --popover: 220 12% 12%;
+    --popover-foreground: 0 0% 98%;
+
+    --primary: 240 62% 55%;
+    --primary-foreground: 0 0% 100%;
+    --primary-hsl: 240 62% 55%;
+
+    --secondary: 210 80% 60%;
+    --secondary-foreground: 0 0% 100%;
+    --secondary-hsl: 210 80% 60%;
+
+    --muted: 220 14% 22%;
+    --muted-foreground: 220 12% 70%;
+
+    --accent: 270 55% 65%;
+    --accent-foreground: 0 0% 100%;
+    --accent-hsl: 270 55% 65%;
+
+    --destructive: 0 63% 31%;
+    --destructive-foreground: 0 0% 98%;
+
+    --border: 220 14% 20%;
+    --input: 220 12% 14%;
+    --ring: 210 80% 60%;
+
+    --hero-gradient-start: 240 62% 55%;
+    --hero-gradient-end: 210 80% 60%;
+    --glow-purple: 240 62% 55%;
+    --glow-blue: 210 80% 60%;
+    --glow-pink: 270 55% 65%;
   }
 }
 
@@ -60,7 +101,7 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans antialiased;
     font-feature-settings: 'rlig' 1, 'calt' 1;
   }
 
@@ -98,7 +139,7 @@ All colors MUST be HSL.
   }
 
   .glass {
-    @apply bg-card border border-border/50; /* Removed /80 and backdrop-blur-xl */
+    @apply rounded-2xl border border-border/60 bg-card/80 shadow-md backdrop-blur-xl;
   }
 
   .glow-purple {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -27,14 +27,14 @@ export default function About() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.6 }}
-          className="glass rounded-[var(--radius)] p-8 md:p-12 mb-12"
+          className="glass mb-12 p-8 md:p-12"
         >
           <div className="flex flex-col md:flex-row gap-8 items-center md:items-start">
-            <div className="w-32 h-32 rounded-[var(--radius)] bg-gradient-to-br from-primary via-secondary to-accent p-1 shrink-0">
+            <div className="h-32 w-32 shrink-0 rounded-2xl bg-gradient-to-br from-primary via-secondary to-accent p-1">
               <img
                 src={cvData.profile.avatar}
                 alt={cvData.profile.name}
-                className="w-full h-full rounded-[calc(var(--radius)-0.25rem)] object-cover"
+                className="h-full w-full rounded-xl object-cover"
               />
             </div>
             
@@ -78,7 +78,7 @@ export default function About() {
                 animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
                 transition={{ delay: 0.5 + index * 0.1, duration: 0.5 }}
                 whileHover={prefersReducedMotion ? undefined : { y: -5, boxShadow: '0 10px 20px rgba(0,0,0,0.2)' }}
-                className="glass rounded-[var(--radius)] p-6 hover:shadow-lg hover:shadow-primary/10 transition-all"
+                className="glass p-6 transition-all hover:shadow-lg"
               >
                 <div className="flex flex-col md:flex-row md:items-start md:justify-between mb-4">
                   <div>
@@ -130,7 +130,7 @@ export default function About() {
                 animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
                 transition={{ delay: 0.7 + index * 0.05, duration: 0.3 }}
                 whileHover={prefersReducedMotion ? undefined : { y: -3, boxShadow: '0 8px 16px rgba(0,0,0,0.15)' }}
-                className="glass rounded-[var(--radius)] p-4 flex items-center justify-between hover:shadow-md transition-shadow"
+                className="glass flex items-center justify-between p-4 transition-shadow hover:shadow-lg"
               >
                 <div>
                   <h4 className="font-semibold mb-1">{skill.name}</h4>

--- a/src/pages/ArtDetail.tsx
+++ b/src/pages/ArtDetail.tsx
@@ -66,7 +66,7 @@ export default function ArtDetail() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_90px_-70px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
+          className="rounded-2xl border border-border/60 bg-card/80 p-10 shadow-lg backdrop-blur-xl"
         >
           <MotionButton
             asChild

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -80,7 +80,7 @@ export default function Contact() {
             transition={{ delay: 0.2, duration: 0.6 }}
             className="space-y-8"
           >
-            <div className="glass rounded-[var(--radius)] p-8">
+            <div className="glass p-8">
               <h2 className="text-2xl font-display font-bold mb-6">
                 Informações de Contato
               </h2>
@@ -137,7 +137,7 @@ export default function Contact() {
               </div>
             </div>
 
-            <div className="glass rounded-[var(--radius)] p-8">
+            <div className="glass p-8">
               <h3 className="font-display font-bold mb-3">Disponibilidade</h3>
               <p className="text-muted-foreground">
                 {cvData.contact.availability}
@@ -151,7 +151,7 @@ export default function Contact() {
             animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
             transition={{ delay: 0.4, duration: 0.6 }}
           >
-            <form onSubmit={handleSubmit} className="glass rounded-[var(--radius)] p-8">
+            <form onSubmit={handleSubmit} className="glass p-8">
               <h2 className="text-2xl font-display font-bold mb-6">
                 Enviar Mensagem
               </h2>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,7 +35,7 @@ export default function Home() {
           >
             <motion.div
               variants={itemVariants}
-              className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/60 px-4 py-2 shadow-[0_20px_35px_-25px_hsl(var(--secondary)/0.2)]"
+              className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/60 px-4 py-2 shadow-md"
             >
               <Sparkles className="w-4 h-4 text-accent" />
               <span className="text-sm font-medium">{cvData.profile.location}</span>
@@ -71,7 +71,7 @@ export default function Home() {
               <Button
                 asChild
                 size="lg"
-                className="rounded-full text-lg px-8 py-6 shadow-[0_15px_45px_-20px_hsl(var(--secondary)/0.4)]"
+                className="rounded-full px-8 py-6"
               >
                 <Link to="/portfolio">
                   <Code2 className="mr-2" />
@@ -103,7 +103,7 @@ export default function Home() {
                 <PenSquare className="h-4 w-4 text-secondary" aria-hidden />
                 <span>Nova rota: reflexões em tecnologia e arte</span>
               </motion.div>
-              <Button asChild className="rounded-full bg-gradient-to-r from-secondary/70 to-primary/70 px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_30px_-24px_hsl(var(--secondary)/0.75)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:brightness-105">
+              <Button asChild className="rounded-full bg-gradient-to-r from-secondary/70 to-primary/70 px-4 py-2 text-sm font-semibold text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:brightness-105">
                 <Link to="/thoughts">
                   Ler os pensamentos recentes
                   <ArrowRight className="h-4 w-4" aria-hidden />
@@ -131,7 +131,7 @@ export default function Home() {
       </section>
 
       {/* Featured Projects */}
-      <section className="py-24 px-6">
+      <section className="px-6 pb-24 pt-32">
         <div className="container mx-auto">
           <motion.div
             initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
@@ -176,9 +176,9 @@ export default function Home() {
                   whileTap={prefersReducedMotion ? undefined : { scale: 0.99 }}
                   transition={{ type: 'spring', stiffness: 200, damping: 22 }}
                 >
-                  <div className="rounded-[var(--radius)] border border-border/70 bg-card/60 p-6 shadow-[0_15px_30px_-20px_hsl(var(--primary)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_50px_-25px_hsl(var(--primary)/0.3),_0_10px_20px_-10px_hsl(var(--secondary)/0.2)]">
+                  <div className="rounded-2xl border border-border/60 bg-card/70 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-xl">
                     <div className="flex items-start justify-between mb-4">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary/80 via-secondary/70 to-accent/70 text-white shadow-[0_0_20px_hsl(var(--primary)/0.2)]">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary/80 via-secondary/70 to-accent/70 text-white shadow-md">
                         <Code2 className="text-white" size={24} aria-hidden />
                       </div>
                       <span className="text-xs font-medium px-3 py-1 rounded-full bg-muted text-muted-foreground">
@@ -228,7 +228,7 @@ export default function Home() {
       </section>
 
       {/* Collections & Art */}
-      <section className="pb-24 px-6">
+      <section className="px-6 pb-24 pt-12">
         <div className="container mx-auto">
           <motion.div
             initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
@@ -256,8 +256,8 @@ export default function Home() {
                 to="/series/creative-systems"
                 className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
-                <div className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/70 p-6 shadow-[0_20px_40px_-30px_hsl(var(--secondary)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_30px_60px_-40px_hsl(var(--secondary)/0.3),_0_15px_30px_-15px_hsl(var(--accent)/0.2)]">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-secondary via-primary to-accent text-white shadow-[0_0_20px_hsl(var(--primary)/0.2)]">
+                <div className="flex h-full flex-col rounded-2xl border border-border/60 bg-card/80 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 hover:shadow-lg">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-secondary via-primary to-accent text-white shadow-md">
                     <Layers aria-hidden className="h-6 w-6" />
                   </div>
                   <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
@@ -280,8 +280,8 @@ export default function Home() {
                 to="/art/artleo"
                 className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
-                <div className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/70 p-6 shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_30px_60px_-40px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-[0_0_20px_hsl(var(--secondary)/0.2)]">
+                <div className="flex h-full flex-col rounded-2xl border border-border/60 bg-card/80 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-xl">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-md">
                     <Palette aria-hidden className="h-6 w-6" />
                   </div>
                   <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -20,7 +20,7 @@ const NotFound = () => {
         initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
         animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
-        className="w-full max-w-xl rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 text-center shadow-[0_45px_85px_-70px_hsl(var(--secondary)/0.3)] backdrop-blur-xl"
+        className="w-full max-w-xl rounded-2xl border border-border/60 bg-card/80 p-10 text-center shadow-lg backdrop-blur-xl"
         role="alert"
         aria-live="assertive"
       >

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -115,7 +115,7 @@ export default function ProjectDetail() {
           variants={containerVariants}
           initial={prefersReducedMotion ? undefined : 'hidden'}
           animate={prefersReducedMotion ? undefined : 'visible'}
-          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_90px_-70px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
+          className="rounded-2xl border border-border/60 bg-card/80 p-10 shadow-lg backdrop-blur-xl"
         >
           <motion.div variants={itemVariants}>
             <MotionButton
@@ -202,19 +202,19 @@ export default function ProjectDetail() {
           {/* Project Metadata */}
           <motion.section variants={itemVariants} className="mt-10 space-y-6">
             <div className="grid gap-4 sm:grid-cols-2 text-sm text-muted-foreground/90">
-              <div className="flex items-center gap-2 rounded-[var(--radius)] border border-border/60 bg-background/60 px-4 py-3">
+              <div className="flex items-center gap-2 rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
                 <Globe className="h-4 w-4 text-secondary" aria-hidden />
                 <span>{project.domain ?? 'Domínio reservado'}</span>
               </div>
-              <div className="flex items-center gap-2 rounded-[var(--radius)] border border-border/60 bg-background/60 px-4 py-3">
+              <div className="flex items-center gap-2 rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
                 <Shield className="h-4 w-4 text-primary" aria-hidden />
                 <span>{project.visibility ?? 'Visibilidade não definida'}</span>
               </div>
-              <div className="flex items-center gap-2 rounded-[var(--radius)] border border-border/60 bg-background/60 px-4 py-3">
+              <div className="flex items-center gap-2 rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
                 <GitBranch className="h-4 w-4 text-emerald-300" aria-hidden />
                 <span>{project.status ?? 'Estado em revisão'}</span>
               </div>
-              <div className="flex items-center gap-2 rounded-[var(--radius)] border border-border/60 bg-background/60 px-4 py-3">
+              <div className="flex items-center gap-2 rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
                 <Layers className="h-4 w-4 text-primary" aria-hidden />
                 <span>{project.category}</span>
               </div>

--- a/src/pages/SeriesDetail.tsx
+++ b/src/pages/SeriesDetail.tsx
@@ -102,7 +102,7 @@ export default function SeriesDetail() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-10 shadow-[0_45px_85px_-70px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
+          className="rounded-2xl border border-border/60 bg-card/80 p-10 shadow-lg backdrop-blur-xl"
         >
           <MotionButton
             asChild
@@ -150,7 +150,7 @@ export default function SeriesDetail() {
             {works.map((work, index) => {
               const card = (
                 <motion.div
-                  className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/80 p-6 shadow-[0_35px_70px_-55px_hsl(var(--secondary)/0.3)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_55px_-35px_hsl(var(--primary)/0.3)]"
+                  className="flex h-full flex-col rounded-2xl border border-border/60 bg-card/80 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-lg"
                   whileHover={prefersReducedMotion ? undefined : { y: -5, boxShadow: '0 10px 20px rgba(0,0,0,0.2)' }}
                 >
                   {work.thumbnail && (
@@ -209,7 +209,7 @@ export default function SeriesDetail() {
               );
             })}
             {works.length === 0 && (
-              <div className="col-span-full rounded-[var(--radius)] border border-border/60 bg-background/60 p-8 text-center text-sm text-muted-foreground">
+              <div className="col-span-full rounded-2xl border border-border/60 bg-background/60 p-8 text-center text-sm text-muted-foreground">
                 Novas obras para esta série serão adicionadas em breve.
               </div>
             )}

--- a/src/pages/ThoughtDetail.tsx
+++ b/src/pages/ThoughtDetail.tsx
@@ -49,7 +49,7 @@ export default function ThoughtDetail() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="rounded-[var(--radius)] border border-border/60 bg-card/80 p-8 shadow-[0_45px_85px_-70px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
+          className="rounded-2xl border border-border/60 bg-card/80 p-8 shadow-lg backdrop-blur-xl"
         >
           <MotionButton
             asChild
@@ -111,7 +111,7 @@ export default function ThoughtDetail() {
             <ReactMarkdown>{thought.body}</ReactMarkdown>
           </article>
 
-          <footer className="mt-12 rounded-[var(--radius)] border border-border/60 bg-background/60 p-6">
+          <footer className="mt-12 rounded-2xl border border-border/60 bg-background/60 p-6 shadow-md">
             <p className="text-sm uppercase tracking-[0.4em] text-muted-foreground">Escrito por</p>
             <div className="mt-4 flex items-center gap-3">
               <img

--- a/src/pages/Thoughts.tsx
+++ b/src/pages/Thoughts.tsx
@@ -59,8 +59,8 @@ export default function Thoughts() {
                   initial={prefersReducedMotion ? undefined : { opacity: 0, y: 30 }}
                   animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
                   transition={{ delay: index * 0.1, duration: 0.45 }}
-                  whileHover={prefersReducedMotion ? undefined : { y: -5, boxShadow: '0 10px 20px rgba(0,0,0,0.2)' }}
-                  className="group flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/80 p-8 shadow-[0_35px_65px_-55px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
+                  whileHover={prefersReducedMotion ? undefined : { y: -5 }}
+                  className="group flex h-full flex-col rounded-2xl border border-border/60 bg-card/80 p-8 shadow-md backdrop-blur-xl transition-shadow hover:shadow-lg"
                 >
                   <div className="mb-6 flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                     <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
@@ -107,7 +107,7 @@ export default function Thoughts() {
             })}
           </div>
 
-          <div className="mt-16 flex flex-col items-center gap-4 rounded-[var(--radius)] border border-border/60 bg-background/40 p-8 text-center shadow-[0_35px_70px_-60px_hsl(var(--secondary)/0.3)]">
+          <div className="mt-16 flex flex-col items-center gap-4 rounded-2xl border border-border/60 bg-background/40 p-8 text-center shadow-md">
             <p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Monynha Softwares Journal</p>
             <p className="text-2xl font-display font-semibold text-foreground">
               Ideias, processos criativos e bastidores das experiências imersivas.


### PR DESCRIPTION
## Summary
- add a light-theme palette, dark overrides, and runtime detection to honour brand tokens across modes
- standardize shadcn buttons/cards and page layouts to use the rounded-2xl + shadow-md profile with updated spacing
- refresh the visual audit report with before/after captures for desktop and mobile states

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4db00bc9c8322b942cf2f7e2d4801