### PR TITLE
feat: audit visual e implementar tema

### DIFF
--- a/audit-report.md
+++ b/audit-report.md
@@ -1,26 +1,41 @@
-# Monynha Portfolio Code Audit Report
+# Auditoria Visual — Marcelo Portigolio
 
-## Código e Organização
-- Remoção do módulo `src/lib/supabase.ts`, que estava obsoleto e não era referenciado no aplicativo.
-- Tipagens aprimoradas nos componentes de UI (`command` e `textarea`) para eliminar interfaces vazias e evitar uso de `any`.
-- Remoção da dependência do Google Translate com a introdução do helper local (`src/lib/language.ts`) para sincronizar o atributo `lang` e eventos de idioma de forma tipada.
+## Sumário
+- Erros encontrados
+- Correções aplicadas
+- Prints de antes/depois
+- Checklist de Conformidade
 
-## Experiência do Usuário & Visual
-- Hero estático atualizado com gradações em HSL, alinhando os visuais aos tons oficiais (#7C3AED, #0EA5E9, #EC4899).
-- Tailwind configurado com famílias `Inter`, `Space Grotesk` e agora `JetBrains Mono`, garantindo consistência tipográfica.
-- Fonte JetBrains carregada no `index.html` para seções de código e detalhes técnicos.
-- Cartões de séries harmonizados (`SeriesDetail`) com semântica de links clara para rotas internas e externas.
-- Pré-visualização 3D das artes agora respeita uma flag `VITE_ENABLE_ART_3D`, evitando carregar bibliotecas pesadas quando o recurso estiver desativado.
+## Erros encontrados
+- Ausência de tema claro: tokens HSL estavam definidos apenas para um modo escuro, impossibilitando a alternância e deixando o botão de acessibilidade ausente na navegação.
+- Componentes shadcn/ui (Buttons, Cards) com `rounded-md`/`rounded-full` e sombras exageradas, destoando da identidade visual especificada (`rounded-2xl`, `shadow-md`).
+- Utilitário `glass` e cartões secundários usando bordas inconsistentes e sombras profundas, gerando contraste insuficiente em superfícies claras.
 
-## Formulários e Integrações
-- Formulário de contato passa a reutilizar um estado inicial imutável e atualizações funcionais de estado, evitando condições de corrida.
-- Logs de Supabase agora aparecem apenas em ambiente de desenvolvimento, mantendo o console limpo em produção.
-- Tratamento de erros no formulário de contato mantém registro apenas em modo desenvolvimento.
+## Correções aplicadas
+- Implementado `ThemeProvider` (next-themes) e toggle acessível no Navbar, além de tokens HSL completos para modo claro/escuro com fontes base normalizadas (`font-sans`, `font-display`).
+- Atualizados componentes shadcn (Buttons, Cards) para `rounded-2xl` + `shadow-md` por padrão e normalizados botões/link cards para remover `rounded-full` customizado.
+- Refatorado utilitário `glass` e superfícies principais (Home, Portfolio, About, Contact, Thoughts) para usar `rounded-2xl`, sombras suaves e chips/pílulas com contrastes dentro da paleta.
 
-## Acessibilidade e Performance
-- Links de cartões no portfólio usam componentes adequados (`Link` ou `<a>`) com foco visível, melhorando navegação por teclado.
-- Imagens de cards continuam com `loading="lazy"` e atributos alt descritivos.
+## Prints e Descrições
 
-## Validações
-- `npm run lint` executado para garantir que não há erros de lint.
-- `npm run build` executado para validar o empacotamento de produção e monitorar o tamanho dos bundles.
+### Home – tema claro indisponível (antes)
+Sem alternância de tema, a paleta permanecia escura e não atendia à diretriz de acessibilidade para tema claro.
+![Home desktop sem tema claro (antes)](browser:/invocations/hffbbdfy/artifacts/artifacts/home-desktop-light-before.png)
+
+### Home – tema claro implementado (depois)
+Toggle visível no Navbar, tokens claros com contraste adequado entre texto e fundo.
+![Home desktop tema claro (depois)](browser:/invocations/zqstetrv/artifacts/artifacts/home-desktop-light-after.png)
+
+### Home – mobile dark (antes)
+Botões arredondados excessivamente e sem consistência de sombras.
+![Home mobile dark (antes)](browser:/invocations/hffbbdfy/artifacts/artifacts/home-mobile-dark-before.png)
+
+### Home – mobile dark revisado (depois)
+Botões `rounded-2xl` com `shadow-md` e toggle funcional.
+![Home mobile dark (depois)](browser:/invocations/zqstetrv/artifacts/artifacts/home-mobile-dark-after.png)
+
+## Checklist de Conformidade
+✅ Paleta e tokens
+✅ Tipografia
+✅ Acessibilidade
+✅ Layout responsivo

--- a/src/components/ArtworkCard.tsx
+++ b/src/components/ArtworkCard.tsx
@@ -28,7 +28,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({ artwork, index }) => {
       transition={{ delay: index * 0.08, duration: 0.4 }}
       className="group"
     >
-      <div className="rounded-[var(--radius)] border border-border/70 bg-card overflow-hidden shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-[0_35px_60px_-45px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
+      <div className="rounded-2xl border border-border/70 bg-card/90 overflow-hidden shadow-md transition-shadow focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-lg">
         <MotionLink
           to={`/art/${artwork.slug}`}
           className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
@@ -41,7 +41,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({ artwork, index }) => {
           whileTap={prefersReducedMotion ? undefined : { scale: 0.99 }}
           transition={{ type: 'spring', stiffness: 200, damping: 22 }}
         >
-          <div className="relative aspect-[16/9] overflow-hidden bg-gradient-to-br from-primary/25 via-secondary/20 to-accent/25">
+          <div className="relative aspect-[16/9] overflow-hidden bg-gradient-to-br from-primary/20 via-secondary/15 to-accent/20">
             <motion.img
               src={artwork.media?.[0]}
               width={640}
@@ -78,7 +78,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({ artwork, index }) => {
               {artwork.materials.map((material: string) => (
                 <span
                   key={material}
-                  className="text-xs px-2 py-1 rounded-md bg-muted/60 text-foreground/80"
+                  className="text-xs px-3 py-1 rounded-xl bg-muted/60 text-foreground/80"
                 >
                   {material}
                 </span>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import MonynhaLogo from './MonynhaLogo'; // Import the new logo component
 import cvData from '../../public/data/cv.json';
+import { ThemeToggle } from './ThemeToggle';
 
 const MotionLink = motion(Link);
 
@@ -38,7 +39,7 @@ export default function Navbar() {
         initial={shouldReduceMotion ? undefined : { y: -100, opacity: 0 }}
         animate={shouldReduceMotion ? undefined : { y: 0, opacity: 1 }}
         transition={{ type: 'spring', stiffness: 120, damping: 15, delay: 0.1 }}
-        className="mx-auto flex max-w-6xl items-center justify-between rounded-full border border-border/60 bg-card/80 px-6 py-3 shadow-[0_20px_45px_-25px_hsl(var(--primary)/0.2)] backdrop-blur-xl"
+        className="mx-auto flex max-w-6xl items-center justify-between gap-4 rounded-full border border-border/60 bg-card/85 px-6 py-3 shadow-md backdrop-blur-xl"
       >
         <MotionLink
           to="/"
@@ -55,12 +56,12 @@ export default function Navbar() {
           </span>
         </MotionLink>
 
-        <div className="hidden flex-1 items-center justify-end gap-6 md:flex">
+        <div className="hidden flex-1 items-center justify-end gap-4 md:flex">
           <motion.div
             variants={menuVariants}
             initial={shouldReduceMotion ? undefined : 'hidden'}
             animate={shouldReduceMotion ? undefined : 'visible'}
-            className="flex items-center gap-2 rounded-full border border-border/60 bg-background/40 p-1"
+            className="flex items-center gap-2 rounded-full border border-border/60 bg-background/60 p-1 shadow-inner"
           >
             {navLinks.map((link) => {
               const active = isActive(link.href);
@@ -69,14 +70,12 @@ export default function Navbar() {
                   key={link.href}
                   to={link.href}
                   className={`relative rounded-full px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
-                    active ? 'text-white' : 'text-muted-foreground hover:text-foreground'
+                    active ? 'text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
                   }`}
                   {...(!shouldReduceMotion
                     ? {
                         whileHover: {
                           y: -2,
-                          boxShadow:
-                            '0 12px 24px -18px hsl(var(--secondary) / 0.3), 0 0 12px hsl(var(--primary) / 0.2)',
                         },
                       }
                     : {})}
@@ -84,7 +83,7 @@ export default function Navbar() {
                   {active && (
                     <motion.span
                       layoutId="nav-pill"
-                      className="absolute inset-0 -z-10 rounded-full bg-gradient-to-r from-primary/90 via-secondary/80 to-accent/80"
+                      className="absolute inset-0 -z-10 rounded-full bg-gradient-to-r from-primary via-secondary to-accent"
                       transition={{ type: 'spring', stiffness: 260, damping: 30 }}
                     />
                   )}
@@ -93,7 +92,7 @@ export default function Navbar() {
               );
             })}
           </motion.div>
-
+          <ThemeToggle />
         </div>
 
         <button
@@ -136,6 +135,7 @@ export default function Navbar() {
                   {link.label}
                 </Link>
               ))}
+              <ThemeToggle className="mt-2" />
             </div>
           </motion.div>
         )}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -49,7 +49,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
       initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
       animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
       transition={{ delay: index * 0.08, duration: 0.45 }}
-      className="group h-full overflow-hidden border-border/70 bg-card/80 shadow-[0_22px_48px_-32px_hsl(var(--primary)_/_0.35)] backdrop-blur"
+      className="group h-full overflow-hidden border-border/70 bg-card/90 shadow-md backdrop-blur"
     >
       <div className="relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br from-primary/25 via-secondary/20 to-accent/25">
         <motion.img
@@ -138,7 +138,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
           {project.stack.map((tech) => (
             <span
               key={tech}
-              className="rounded-md border border-border/60 bg-background/60 px-2 py-1 text-[0.7rem] font-medium text-foreground/85"
+              className="rounded-xl border border-border/60 bg-background/70 px-3 py-1 text-[0.7rem] font-medium text-foreground/85"
             >
               {tech}
             </span>
@@ -151,7 +151,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
           variant="outline"
           size="sm"
           asChild
-          className="rounded-full border-border/70 text-xs font-semibold"
+          className="border-border/70 text-xs font-semibold"
         >
           <a
             href={project.repoUrl}
@@ -170,7 +170,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
             variant="secondary"
             size="sm"
             asChild
-            className="rounded-full border border-secondary/40 text-xs font-semibold"
+            className="border border-secondary/40 text-xs font-semibold"
           >
             <a
               href={liveLink}

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -26,7 +26,7 @@ const SeriesCard: React.FC<SeriesCardProps> = ({ series, index }) => {
       transition={{ delay: index * 0.08, duration: 0.4 }}
       className="group"
     >
-      <div className="rounded-[var(--radius)] border border-border/70 bg-card overflow-hidden shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-[0_35px_60px_-45px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
+      <div className="rounded-2xl border border-border/70 bg-card/90 overflow-hidden shadow-md transition-shadow focus-within:outline-none focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-2 focus-within:ring-offset-background group-hover:shadow-lg">
         <MotionLink
           to={`/series/${series.slug}`}
           className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
@@ -39,7 +39,7 @@ const SeriesCard: React.FC<SeriesCardProps> = ({ series, index }) => {
           whileTap={prefersReducedMotion ? undefined : { scale: 0.99 }}
           transition={{ type: 'spring', stiffness: 200, damping: 22 }}
         >
-          <div className="relative aspect-[16/9] overflow-hidden bg-gradient-to-br from-primary/25 via-secondary/20 to-accent/25 flex items-center justify-center">
+          <div className="relative aspect-[16/9] overflow-hidden bg-gradient-to-br from-primary/20 via-secondary/15 to-accent/20 flex items-center justify-center">
             <Layers className="h-24 w-24 text-white/50" aria-hidden />
             <div className="absolute top-4 right-4">
               <span className="rounded-full border border-border/60 bg-background/70 px-3 py-1 text-xs font-medium">
@@ -64,7 +64,7 @@ const SeriesCard: React.FC<SeriesCardProps> = ({ series, index }) => {
 
             <div className="flex flex-wrap gap-2">
               {series.works.length > 0 && (
-                <span className="text-xs px-2 py-1 rounded-md bg-muted/60 text-foreground/80">
+                <span className="text-xs px-3 py-1 rounded-xl bg-muted/60 text-foreground/80">
                   {series.works.length} obras
                 </span>
               )}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const handleToggle = () => {
+    if (!mounted) return;
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      onClick={handleToggle}
+      aria-pressed={resolvedTheme === "dark"}
+      aria-label={
+        resolvedTheme === "dark"
+          ? "Ativar tema claro"
+          : "Ativar tema escuro"
+      }
+      className={cn(
+        "relative h-11 w-11 rounded-2xl border-border/70 bg-card/80 text-foreground shadow-md transition-colors hover:text-primary",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
+      disabled={!mounted}
+    >
+      <Sun className="h-5 w-5 transition-all dark:-rotate-90 dark:scale-0" aria-hidden />
+      <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" aria-hidden />
+      <span className="sr-only">
+        {resolvedTheme === "dark" ? "Tema claro" : "Tema escuro"}
+      </span>
+    </Button>
+  );
+}

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,16 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,25 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-2xl text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 shadow-md",
   {
     variants: {
       variant: {
-        default: "bg-gradient-to-r from-primary to-secondary text-primary-foreground shadow-lg hover:brightness-110", // Gradient for default
+        default: "bg-gradient-to-r from-primary to-secondary text-primary-foreground hover:brightness-110",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-muted text-muted-foreground hover:bg-muted/80", // Darker secondary
+          "bg-muted text-muted-foreground hover:bg-muted/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "h-11 px-6",
+        sm: "h-9 rounded-xl px-4 text-xs",
+        lg: "h-12 rounded-3xl px-10 text-base",
+        icon: "h-11 w-11",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  <div ref={ref} className={cn("rounded-2xl border bg-card text-card-foreground shadow-md", className)} {...props} />
 ));
 Card.displayName = "Card";
 

--- a/src/index.css
+++ b/src/index.css
@@ -8,49 +8,86 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    --background: 220 10% 8%; /* Very dark gray, almost black */
-    --foreground: 0 0% 98%; /* White for text */
+    --background: 216 33% 96%;
+    --foreground: 222 47% 11%;
 
-    --card: 220 10% 12%; /* Slightly lighter dark gray for card backgrounds */
-    --card-foreground: 0 0% 98%;
+    --card: 0 0% 100%;
+    --card-foreground: 222 47% 11%;
 
-    --popover: 220 10% 12%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222 47% 11%;
 
-    --primary: 240 60% 40%; /* Deep Indigo */
-    --primary-foreground: 0 0% 98%; /* White for text on primary buttons */
-    --primary-hsl: 240 60% 40%;
+    --primary: 243 75% 59%;
+    --primary-foreground: 210 40% 98%;
+    --primary-hsl: 243 75% 59%;
 
-    --secondary: 210 70% 50%; /* Vibrant Sky Blue */
-    --secondary-foreground: 0 0% 98%;
-    --secondary-hsl: 210 70% 50%;
+    --secondary: 199 89% 48%;
+    --secondary-foreground: 210 40% 98%;
+    --secondary-hsl: 199 89% 48%;
 
-    --muted: 220 10% 25%; /* Medium dark gray for muted backgrounds */
-    --muted-foreground: 220 10% 70%; /* Light gray for muted text */
+    --muted: 216 33% 90%;
+    --muted-foreground: 222 27% 32%;
 
-    --accent: 270 40% 60%; /* Soft Lavender Purple */
-    --accent-foreground: 0 0% 98%;
-    --accent-hsl: 270 40% 60%;
+    --accent: 281 66% 60%;
+    --accent-foreground: 210 40% 98%;
+    --accent-hsl: 281 66% 60%;
 
-    --destructive: 0 63% 31%; /* Keep vibrant red */
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 210 40% 98%;
 
-    --border: 220 10% 20%; /* Subtle dark gray border */
-    --input: 220 10% 12%; /* Dark input background */
-    --ring: 210 70% 50%; /* Secondary blue for focus ring */
+    --border: 214 32% 86%;
+    --input: 216 33% 94%;
+    --ring: 199 89% 48%;
 
-    --radius: 1.5rem; /* Increased border radius for softer, polished look */
+    --radius: 1.5rem;
 
-    /* Custom tokens */
-    --hero-gradient-start: 240 60% 40%;
-    --hero-gradient-end: 210 70% 50%;
-    --glow-purple: 240 60% 40%;
-    --glow-blue: 210 70% 50%;
-    --glow-pink: 270 40% 60%;
-    
-    /* Animations */
+    --hero-gradient-start: 243 75% 59%;
+    --hero-gradient-end: 199 89% 48%;
+    --glow-purple: 243 75% 59%;
+    --glow-blue: 199 89% 48%;
+    --glow-pink: 281 66% 60%;
+
     --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     --transition-bounce: all 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  }
+
+  .dark {
+    --background: 222 47% 7%;
+    --foreground: 210 40% 96%;
+
+    --card: 222 45% 12%;
+    --card-foreground: 210 40% 96%;
+
+    --popover: 222 45% 10%;
+    --popover-foreground: 210 40% 96%;
+
+    --primary: 244 63% 68%;
+    --primary-foreground: 222 100% 98%;
+    --primary-hsl: 244 63% 68%;
+
+    --secondary: 199 89% 60%;
+    --secondary-foreground: 222 100% 98%;
+    --secondary-hsl: 199 89% 60%;
+
+    --muted: 223 23% 20%;
+    --muted-foreground: 218 14% 72%;
+
+    --accent: 281 66% 68%;
+    --accent-foreground: 222 100% 98%;
+    --accent-hsl: 281 66% 68%;
+
+    --destructive: 0 84% 63%;
+    --destructive-foreground: 222 100% 98%;
+
+    --border: 224 22% 26%;
+    --input: 224 22% 20%;
+    --ring: 199 89% 60%;
+
+    --hero-gradient-start: 244 63% 68%;
+    --hero-gradient-end: 199 89% 60%;
+    --glow-purple: 244 63% 68%;
+    --glow-blue: 199 89% 60%;
+    --glow-pink: 281 66% 68%;
   }
 }
 
@@ -60,8 +97,22 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background font-sans text-foreground antialiased;
     font-feature-settings: 'rlig' 1, 'calt' 1;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-display tracking-tight;
+  }
+
+  code,
+  pre {
+    @apply font-mono;
   }
 
   :focus-visible {
@@ -98,7 +149,7 @@ All colors MUST be HSL.
   }
 
   .glass {
-    @apply bg-card border border-border/50; /* Removed /80 and backdrop-blur-xl */
+    @apply rounded-2xl border border-border/50 bg-card shadow-md;
   }
 
   .glow-purple {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { ThemeProvider } from "./components/providers/theme-provider";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>,
+);

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -27,15 +27,17 @@ export default function About() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.6 }}
-          className="glass rounded-[var(--radius)] p-8 md:p-12 mb-12"
+          className="glass mb-12 p-8 md:p-12"
         >
           <div className="flex flex-col md:flex-row gap-8 items-center md:items-start">
-            <div className="w-32 h-32 rounded-[var(--radius)] bg-gradient-to-br from-primary via-secondary to-accent p-1 shrink-0">
-              <img
-                src={cvData.profile.avatar}
-                alt={cvData.profile.name}
-                className="w-full h-full rounded-[calc(var(--radius)-0.25rem)] object-cover"
-              />
+            <div className="relative h-32 w-32 shrink-0 rounded-2xl bg-gradient-to-br from-primary via-secondary to-accent p-1 shadow-md">
+              <div className="h-full w-full overflow-hidden rounded-[1.25rem]">
+                <img
+                  src={cvData.profile.avatar}
+                  alt={cvData.profile.name}
+                  className="h-full w-full object-cover"
+                />
+              </div>
             </div>
             
             <div className="flex-1 text-center md:text-left">
@@ -78,7 +80,7 @@ export default function About() {
                 animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
                 transition={{ delay: 0.5 + index * 0.1, duration: 0.5 }}
                 whileHover={prefersReducedMotion ? undefined : { y: -5, boxShadow: '0 10px 20px rgba(0,0,0,0.2)' }}
-                className="glass rounded-[var(--radius)] p-6 hover:shadow-lg hover:shadow-primary/10 transition-all"
+                className="glass p-6 hover:shadow-lg hover:shadow-primary/10 transition-all"
               >
                 <div className="flex flex-col md:flex-row md:items-start md:justify-between mb-4">
                   <div>
@@ -130,7 +132,7 @@ export default function About() {
                 animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
                 transition={{ delay: 0.7 + index * 0.05, duration: 0.3 }}
                 whileHover={prefersReducedMotion ? undefined : { y: -3, boxShadow: '0 8px 16px rgba(0,0,0,0.15)' }}
-                className="glass rounded-[var(--radius)] p-4 flex items-center justify-between hover:shadow-md transition-shadow"
+                className="glass flex items-center justify-between p-4 transition-shadow hover:shadow-lg"
               >
                 <div>
                   <h4 className="font-semibold mb-1">{skill.name}</h4>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -80,7 +80,7 @@ export default function Contact() {
             transition={{ delay: 0.2, duration: 0.6 }}
             className="space-y-8"
           >
-            <div className="glass rounded-[var(--radius)] p-8">
+            <div className="glass p-8">
               <h2 className="text-2xl font-display font-bold mb-6">
                 Informações de Contato
               </h2>
@@ -92,7 +92,7 @@ export default function Contact() {
                   whileHover={prefersReducedMotion ? undefined : { x: 5, boxShadow: '0 5px 15px rgba(0,0,0,0.1)' }}
                   transition={{ type: 'spring', stiffness: 300, damping: 20 }}
                 >
-                  <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 transition-colors group-hover:bg-primary/20">
                     <Mail className="text-primary" />
                   </div>
                   <div>
@@ -109,7 +109,7 @@ export default function Contact() {
                   whileHover={prefersReducedMotion ? undefined : { x: 5, boxShadow: '0 5px 15px rgba(0,0,0,0.1)' }}
                   transition={{ type: 'spring', stiffness: 300, damping: 20 }}
                 >
-                  <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 transition-colors group-hover:bg-primary/20">
                     <Github className="text-primary" />
                   </div>
                   <div>
@@ -126,7 +126,7 @@ export default function Contact() {
                   whileHover={prefersReducedMotion ? undefined : { x: 5, boxShadow: '0 5px 15px rgba(0,0,0,0.1)' }}
                   transition={{ type: 'spring', stiffness: 300, damping: 20 }}
                 >
-                  <div className="w-12 h-12 rounded-xl bg-secondary/10 flex items-center justify-center group-hover:bg-secondary/20 transition-colors">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary/10 transition-colors group-hover:bg-secondary/20">
                     <Linkedin className="text-secondary" />
                   </div>
                   <div>
@@ -137,7 +137,7 @@ export default function Contact() {
               </div>
             </div>
 
-            <div className="glass rounded-[var(--radius)] p-8">
+            <div className="glass p-8">
               <h3 className="font-display font-bold mb-3">Disponibilidade</h3>
               <p className="text-muted-foreground">
                 {cvData.contact.availability}
@@ -151,7 +151,7 @@ export default function Contact() {
             animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
             transition={{ delay: 0.4, duration: 0.6 }}
           >
-            <form onSubmit={handleSubmit} className="glass rounded-[var(--radius)] p-8">
+            <form onSubmit={handleSubmit} className="glass p-8">
               <h2 className="text-2xl font-display font-bold mb-6">
                 Enviar Mensagem
               </h2>
@@ -170,7 +170,7 @@ export default function Contact() {
                         setFormData((prev) => ({ ...prev, name: e.target.value }))
                       }
                       required
-                      className="rounded-xl"
+                      className="rounded-2xl"
                       placeholder="Seu nome"
                     />
                   </div>
@@ -185,7 +185,7 @@ export default function Contact() {
                       onChange={(e) =>
                         setFormData((prev) => ({ ...prev, company: e.target.value }))
                       }
-                      className="rounded-xl"
+                      className="rounded-2xl"
                       placeholder="Onde você trabalha"
                     />
                   </div>
@@ -204,7 +204,7 @@ export default function Contact() {
                         setFormData((prev) => ({ ...prev, email: e.target.value }))
                       }
                       required
-                      className="rounded-xl"
+                      className="rounded-2xl"
                       placeholder="seu@email.com"
                     />
                   </div>
@@ -219,7 +219,7 @@ export default function Contact() {
                       onChange={(e) =>
                         setFormData((prev) => ({ ...prev, project: e.target.value }))
                       }
-                      className="rounded-xl"
+                      className="rounded-2xl"
                       placeholder="Sobre o que vamos falar?"
                     />
                   </div>
@@ -237,7 +237,7 @@ export default function Contact() {
                     }
                     required
                     rows={6}
-                    className="rounded-xl resize-none"
+                    className="rounded-2xl resize-none"
                     placeholder="Escreva sua mensagem aqui..."
                   />
                 </div>
@@ -245,7 +245,7 @@ export default function Contact() {
                 <Button
                   type="submit"
                   disabled={isSubmitting}
-                  className="w-full rounded-xl py-6 text-lg bg-primary hover:bg-primary/90"
+                  className="w-full rounded-2xl bg-primary py-6 text-lg hover:bg-primary/90"
                 >
                   {isSubmitting ? (
                     'Enviando...'

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -71,7 +71,7 @@ export default function Home() {
               <Button
                 asChild
                 size="lg"
-                className="rounded-full text-lg px-8 py-6 shadow-[0_15px_45px_-20px_hsl(var(--secondary)/0.4)]"
+                className="px-10 shadow-lg shadow-secondary/30"
               >
                 <Link to="/portfolio">
                   <Code2 className="mr-2" />
@@ -84,7 +84,7 @@ export default function Home() {
                 asChild
                 variant="outline"
                 size="lg"
-                className="rounded-full text-lg px-8 py-6 border-2 border-border/80 bg-card/30 backdrop-blur-sm transition hover:border-primary/80 hover:text-primary"
+                className="border-2 border-border/70 bg-card/60 px-10 hover:border-primary/70 hover:text-primary"
               >
                 <Link to="/contact">
                   Entre em Contato
@@ -103,7 +103,7 @@ export default function Home() {
                 <PenSquare className="h-4 w-4 text-secondary" aria-hidden />
                 <span>Nova rota: reflexões em tecnologia e arte</span>
               </motion.div>
-              <Button asChild className="rounded-full bg-gradient-to-r from-secondary/70 to-primary/70 px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_30px_-24px_hsl(var(--secondary)/0.75)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:brightness-105">
+              <Button asChild className="bg-gradient-to-r from-secondary/80 to-primary/80 px-5 text-sm font-semibold text-white shadow-md hover:brightness-105">
                 <Link to="/thoughts">
                   Ler os pensamentos recentes
                   <ArrowRight className="h-4 w-4" aria-hidden />
@@ -176,12 +176,12 @@ export default function Home() {
                   whileTap={prefersReducedMotion ? undefined : { scale: 0.99 }}
                   transition={{ type: 'spring', stiffness: 200, damping: 22 }}
                 >
-                  <div className="rounded-[var(--radius)] border border-border/70 bg-card/60 p-6 shadow-[0_15px_30px_-20px_hsl(var(--primary)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_50px_-25px_hsl(var(--primary)/0.3),_0_10px_20px_-10px_hsl(var(--secondary)/0.2)]">
+                  <div className="rounded-2xl border border-border/70 bg-card/70 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-lg">
                     <div className="flex items-start justify-between mb-4">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary/80 via-secondary/70 to-accent/70 text-white shadow-[0_0_20px_hsl(var(--primary)/0.2)]">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/80 via-secondary/70 to-accent/70 text-white shadow-md">
                         <Code2 className="text-white" size={24} aria-hidden />
                       </div>
-                      <span className="text-xs font-medium px-3 py-1 rounded-full bg-muted text-muted-foreground">
+                        <span className="text-xs font-medium px-3 py-1 rounded-full bg-muted text-muted-foreground">
                         {project.category}
                       </span>
                     </div>
@@ -198,7 +198,7 @@ export default function Home() {
                       {project.stack.slice(0, 3).map((tech) => (
                         <span
                           key={tech}
-                          className="text-xs px-2 py-1 rounded-md bg-muted/60 text-foreground/80"
+                          className="text-xs px-3 py-1 rounded-xl bg-muted/60 text-foreground/80"
                         >
                           {tech}
                         </span>
@@ -217,7 +217,7 @@ export default function Home() {
             viewport={{ once: true }}
             className="text-center mt-12"
           >
-            <Button asChild variant="outline" size="lg" className="rounded-full border-border/70">
+            <Button asChild variant="outline" size="lg" className="border-border/70">
               <Link to="/portfolio">
                 Ver Todos os Projetos
                 <ArrowRight className="ml-2" />
@@ -256,8 +256,8 @@ export default function Home() {
                 to="/series/creative-systems"
                 className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
-                <div className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/70 p-6 shadow-[0_20px_40px_-30px_hsl(var(--secondary)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_30px_60px_-40px_hsl(var(--secondary)/0.3),_0_15px_30px_-15px_hsl(var(--accent)/0.2)]">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-secondary via-primary to-accent text-white shadow-[0_0_20px_hsl(var(--primary)/0.2)]">
+                <div className="flex h-full flex-col rounded-2xl border border-border/70 bg-card/70 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-lg">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary via-primary to-accent text-white shadow-md">
                     <Layers aria-hidden className="h-6 w-6" />
                   </div>
                   <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
@@ -280,8 +280,8 @@ export default function Home() {
                 to="/art/artleo"
                 className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
-                <div className="flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/70 p-6 shadow-[0_20px_40px_-30px_hsl(var(--accent)/0.1)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_30px_60px_-40px_hsl(var(--accent)/0.3),_0_15px_30px_-15px_hsl(var(--primary)/0.2)]">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-[0_0_20px_hsl(var(--secondary)/0.2)]">
+                <div className="flex h-full flex-col rounded-2xl border border-border/70 bg-card/70 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-lg">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-md">
                     <Palette aria-hidden className="h-6 w-6" />
                   </div>
                   <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -143,9 +143,9 @@ export default function Portfolio() {
               key={category}
               variant={filter === category ? 'default' : 'outline'}
               onClick={() => setFilter(category)}
-              className={`rounded-full border-border/70 transition ${
+              className={`border-border/70 transition ${
                 filter === category
-                  ? 'bg-gradient-to-r from-primary via-secondary to-accent text-white'
+                  ? 'bg-gradient-to-r from-primary via-secondary to-accent text-primary-foreground'
                   : 'hover:border-primary/60 hover:text-primary'
               }`}
             >

--- a/src/pages/Thoughts.tsx
+++ b/src/pages/Thoughts.tsx
@@ -25,7 +25,7 @@ export default function Thoughts() {
           <Button
             asChild
             variant="ghost"
-            className="mb-8 rounded-full border border-border/60 bg-card/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+            className="mb-8 border border-border/60 bg-card/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
           >
             <Link to="/">
               <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
@@ -59,15 +59,15 @@ export default function Thoughts() {
                   initial={prefersReducedMotion ? undefined : { opacity: 0, y: 30 }}
                   animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
                   transition={{ delay: index * 0.1, duration: 0.45 }}
-                  whileHover={prefersReducedMotion ? undefined : { y: -5, boxShadow: '0 10px 20px rgba(0,0,0,0.2)' }}
-                  className="group flex h-full flex-col rounded-[var(--radius)] border border-border/70 bg-card/80 p-8 shadow-[0_35px_65px_-55px_hsl(var(--primary)/0.3)] backdrop-blur-xl"
+                  whileHover={prefersReducedMotion ? undefined : { y: -4, boxShadow: '0 16px 32px -24px rgba(16,24,40,0.35)' }}
+                  className="group flex h-full flex-col rounded-2xl border border-border/70 bg-card/90 p-8 shadow-md backdrop-blur"
                 >
                   <div className="mb-6 flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1">
                       <Calendar className="h-3 w-3" aria-hidden />
                       {formattedDate}
                     </span>
-                    <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1">
                       <BookOpen className="h-3 w-3" aria-hidden />
                       {readingTime} min
                     </span>
@@ -85,7 +85,7 @@ export default function Thoughts() {
                     {thought.tags.map((tag) => (
                       <span
                         key={`${thought.slug}-${tag}`}
-                        className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground"
+                        className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background/70 px-3 py-1 text-xs font-medium text-muted-foreground"
                       >
                         <Tag className="h-3 w-3" aria-hidden />
                         {tag}
@@ -96,7 +96,7 @@ export default function Thoughts() {
                   <div className="mt-auto pt-6">
                     <Link
                       to={`/thoughts/${thought.slug}`}
-                      className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary/70 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      className="inline-flex items-center gap-2 rounded-2xl border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary/70 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                     >
                       Ler Reflexão Completa
                       <ArrowRight className="h-4 w-4" aria-hidden />
@@ -107,12 +107,12 @@ export default function Thoughts() {
             })}
           </div>
 
-          <div className="mt-16 flex flex-col items-center gap-4 rounded-[var(--radius)] border border-border/60 bg-background/40 p-8 text-center shadow-[0_35px_70px_-60px_hsl(var(--secondary)/0.3)]">
+          <div className="mt-16 flex flex-col items-center gap-4 rounded-2xl border border-border/60 bg-background/40 p-8 text-center shadow-md">
             <p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Monynha Softwares Journal</p>
             <p className="text-2xl font-display font-semibold text-foreground">
               Ideias, processos criativos e bastidores das experiências imersivas.
             </p>
-            <Button asChild className="rounded-full bg-gradient-to-r from-secondary/70 to-primary/70 px-6 py-2 text-sm">
+            <Button asChild className="bg-gradient-to-r from-secondary/75 to-primary/75 px-6 py-2 text-sm">
               <Link to="/contact">Partilhar um pensamento comigo</Link>
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- adiciona ThemeProvider e toggle de tema com tokens HSL alinhados à paleta da marca
- normaliza componentes shadcn (buttons, cards, utilitário glass) para rounded-2xl e shadow-md
- revisa páginas principais para contrastes consistentes e atualiza relatório de auditoria com prints antes/depois

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f4db00bc9c8322b942cf2f7e2d4801