### PR TITLE
Adjust mobile navbar theme toggle placement and update contact email

### DIFF
--- a/public/data/cv.json
+++ b/public/data/cv.json
@@ -12,7 +12,7 @@
     "org": "https://github.com/Monynha-Softwares",
     "site": "https://monynha.com",
     "linkedin": "https://www.linkedin.com/in/marcelo-m7",
-    "email": "mailto:geral@monynha.com"
+    "email": "mailto:marcelo@monynha.com"
   },
   "projects": [
     {
@@ -332,7 +332,7 @@
     }
   ],
   "contact": {
-    "email": "geral@monynha.com",
+    "email": "marcelo@monynha.com",
     "availability": "Disponível para colaborações e oportunidades criativas.",
     "note": "Entre em contato para projetos, parcerias ou ideias fora da caixa!",
     "successMessage": "Mensagem enviada com sucesso! Entrarei em contato em breve 🌈",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -95,14 +95,17 @@ export default function Navbar() {
           <ThemeToggle />
         </div>
 
-        <button
-          onClick={() => setIsOpen(!isOpen)}
-          className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-card/70 text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background md:hidden"
-          aria-label="Abrir menu"
-          aria-expanded={isOpen}
-        >
-          {isOpen ? <X size={20} /> : <Menu size={20} />}
-        </button>
+        <div className="flex items-center gap-2 md:hidden">
+          <ThemeToggle className="h-10 w-10 md:hidden" />
+          <button
+            onClick={() => setIsOpen(!isOpen)}
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-card/70 text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            aria-label={isOpen ? 'Fechar menu' : 'Abrir menu'}
+            aria-expanded={isOpen}
+          >
+            {isOpen ? <X size={20} /> : <Menu size={20} />}
+          </button>
+        </div>
       </motion.div>
 
       <AnimatePresence>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -35,7 +35,7 @@ export default function Contact() {
           name: formData.name,
           email: formData.email,
           message: formData.message,
-          to: 'hello@monynha.com',
+          to: 'marcelo@monynha.com',
         },
       });
 


### PR DESCRIPTION
## Summary
- reposition the theme toggle on mobile navigation so it sits beside the menu trigger and keeps accessibility labels updated
- update the contact metadata and form submission address to use marcelo@monynha.com

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f4f01f472c8322928672bbd6254994