### PR TITLE
Stabilize LiquidEther palette updates and mobile coverage

### DIFF
--- a/src/components/LiquidEther.css
+++ b/src/components/LiquidEther.css
@@ -3,5 +3,7 @@
   overflow: hidden;
   width: 100%;
   height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   touch-action: none;
 }


### PR DESCRIPTION
## Summary
- add type-safe references and a reusable palette texture helper for LiquidEther
- update the WebGL palette in place on theme changes to avoid costly background reinitialization
- enforce a dynamic viewport minimum height so the LiquidEther background stays visible on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f4f5dbb1ac8322b889db79a8e94964