### PR TITLE
Update BotecoPro project URL

### DIFF
--- a/public/data/cv.json
+++ b/public/data/cv.json
@@ -25,8 +25,8 @@
         "Flutter",
         "React"
       ],
-      "url": "https://monynha.com",
-      "domain": "monynha.com",
+      "url": "https://botecopeo.monynha.com",
+      "domain": "botecopeo.monynha.com",
       "repoUrl": "https://github.com/Monynha-Softwares/BotecoPro",
       "thumbnail": "/images/botecopro.svg",
       "category": "Soluções Empresariais",


### PR DESCRIPTION
## Summary
- update the BotecoPro project entry to point to the new botecopeo.monynha.com domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8ef9db68c8322a0c1dc60295667ab