### PR TITLE
fix: improve mobile UX (dvh units, navbar overflow, disable 3D on mobile)

### DIFF
--- a/src/components/HeroCanvas.tsx
+++ b/src/components/HeroCanvas.tsx
@@ -100,7 +100,7 @@ export default function HeroCanvas() {
   const prefersReducedMotion = usePrefersReducedMotion();
 
   return (
-    <div className="pointer-events-none absolute inset-0 -z-10">
+    <div className="hidden md:block pointer-events-none absolute inset-0 -z-10">
       <Canvas
         camera={{ position: [0, 0, 5.5], fov: 45 }}
         dpr={[1, 1.6]}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,29 +10,31 @@ export default function Layout() {
   const themeColors = useThemePalette();
 
   return (
-    <div className="relative flex flex-col min-h-screen">
+    <div className="relative flex flex-col min-h-[100dvh]">
       {/* LiquidEther Background */}
-      <div className="fixed inset-0 w-full h-full -z-20">
-        <LiquidEther
-          // Removed key={location.pathname} to prevent remounting and state reset on route changes
-          colors={themeColors}
-          mouseForce={20}
-          cursorSize={100}
-          isViscous={false}
-          viscous={30}
-          iterationsViscous={32}
-          iterationsPoisson={32}
-          dt={0.014}
-          BFECC={true}
-          resolution={0.5}
-          isBounce={false}
-          autoDemo={true}
-          autoSpeed={0.5}
-          autoIntensity={2.2}
-          takeoverDuration={0.25}
-          autoResumeDelay={3000}
-          autoRampDuration={0.6}
-        />
+      <div className="hidden md:block">
+        <div className="fixed inset-0 w-full h-full -z-20">
+          <LiquidEther
+            // Removed key={location.pathname} to prevent remounting and state reset on route changes
+            colors={themeColors}
+            mouseForce={20}
+            cursorSize={100}
+            isViscous={false}
+            viscous={30}
+            iterationsViscous={32}
+            iterationsPoisson={32}
+            dt={0.014}
+            BFECC={true}
+            resolution={0.5}
+            isBounce={false}
+            autoDemo={true}
+            autoSpeed={0.5}
+            autoIntensity={2.2}
+            takeoverDuration={0.25}
+            autoResumeDelay={3000}
+            autoRampDuration={0.6}
+          />
+        </div>
       </div>
       
       <Navbar />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -34,7 +34,7 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="fixed left-1/2 top-4 z-50 w-full -translate-x-1/2 px-4 sm:px-6">
+    <nav className="fixed inset-x-0 top-4 z-50 w-full px-4 sm:px-6">
       <motion.div
         initial={shouldReduceMotion ? undefined : { y: -100, opacity: 0 }}
         animate={shouldReduceMotion ? undefined : { y: 0, opacity: 1 }}

--- a/src/index.css
+++ b/src/index.css
@@ -97,7 +97,7 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background font-sans text-foreground antialiased;
+    @apply bg-background font-sans text-foreground antialiased overflow-x-hidden;
     font-feature-settings: 'rlig' 1, 'calt' 1;
   }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -29,7 +29,7 @@ export default function Home() {
   return (
     <div>
       {/* Hero Section */}
-      <section className="relative min-h-[calc(100vh-8rem)] flex items-center justify-center overflow-hidden py-16">
+      <section className="relative min-h-[calc(100dvh-8rem)] flex items-center justify-center overflow-hidden py-16">
         <div className="container mx-auto px-6 relative z-10">
           <motion.div
             variants={containerVariants}


### PR DESCRIPTION
## Summary
- replace viewport height utilities with dvh-based values to stabilize hero sizing on mobile
- adjust navbar positioning and add global overflow-x guard to remove horizontal scrolling
- hide GPU-intensive background and hero canvas effects on small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa7aba423c83229b40588a7c336431