### PR TITLE
feat: lazy-load Home sections, add GitHub highlights, 3D fallback & SEO improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,23 +2,20 @@
 # The app works without these, but contact form submissions won't persist to database.
 # Get these values from: https://supabase.com/dashboard → Your Project → Settings → API
 
-# Your Supabase project URL (e.g., https://abcdefghijklmnop.supabase.co)
-VITE_SUPABASE_URL=https://pkjigvacvddcnlxhvvba.supabase.co
-
-# Your Supabase anonymous/public key (safe to expose in client-side code)
-VITE_SUPABASE_KEY=sb_publishable_0MizTXBMEspPU_z4tSBfUA_59r4vYX6
-
-# Default schema to use for queries (use 'public' for shared tables, 'portfolio' for project-specific)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_KEY=your-public-anon-key
 VITE_SUPABASE_SCHEMA=portfolio
-VITE_ENABLE_ART_3D=true
-# Note: The VITE_ prefix makes these available in client-side code.
-# The anon/public key only allows operations permitted by Row Level Security (RLS) policies.
-# See SUPABASE.md for complete setup instructions and database schema details.
 
-# ========================================
-# TRANSLATION SYSTEM
-# ========================================
-# No API key required! The translation system now uses Google Translate's free web endpoint.
-# Automatic translation of dynamic content (projects, bio, thoughts) works out of the box.
-# Supports: Portuguese (PT), English (EN), Spanish (ES), French (FR)
-# See TRANSLATION_SYSTEM.md for details.
+# Feature flags
+VITE_ENABLE_ART_3D=true
+
+# GitHub dynamic content
+# GraphQL is preferred when a token is present; REST fallback still works for public repos.
+VITE_GITHUB_USERNAME=marcelo-m7
+VITE_GITHUB_ORG=Monynha-Softwares
+VITE_GITHUB_TOKEN=
+VITE_GITHUB_GRAPHQL_ENDPOINT=https://api.github.com/graphql
+VITE_GITHUB_REST_ENDPOINT=https://api.github.com
+
+# Translation system
+# No API key required. Dynamic content can fall back to cached/local translations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,84 @@
-# Agents guide
+# AGENTS.md
 
-This repository uses AI coding agents to automate small changes and keep docs/code healthy. Start here for conventions and where to look.
+## Objetivo
+Transformar o MS-Portfolio em um produto técnico de alto nível para Marcelo Santos dentro do ecossistema Monynha Softwares, equilibrando identidade pessoal, branding institucional, performance, dados dinâmicos e arquitetura preparada para evolução contínua.
 
-- Project docs: ./docs/
-- AI instructions: .github/copilot-instructions.md
-- Conduct and component rules: ./AI_RULES.md
+## Stack
+- Vite
+- React + TypeScript
+- Tailwind CSS
+- shadcn/ui
+- Framer Motion
+- OGL / experiências 3D e componentes Three.js relacionados
+- TanStack Query
+- i18n próprio
+- Supabase opcional
+- Vitest
 
-## Quick links
-
-- Install: see README.md (root)
-- Dev server: `npm run dev` (port 8080)
+## Setup
+- Instalação: `npm install`
+- Desenvolvimento: `npm run dev`
 - Build: `npm run build`
-- Test: `npm run test`
 - Lint: `npm run lint`
+- Testes: `npm run test`
+- Variáveis principais: `.env.example`
+- Configuração central de produto/brand/endpoints: `src/config/site.ts`
 
-## Typical agent tasks
+## Estrutura relevante
+- `src/components/` → componentes visuais e blocos reutilizáveis
+- `src/components/sections/` → seções de páginas prontas para code splitting
+- `src/components/background/` → experiências de fundo e fallbacks leves
+- `src/hooks/` → hooks de dados, SEO, capacidades do dispositivo e UX
+- `src/lib/` → serviços, integrações externas, utilitários e loaders
+- `src/config/` → branding, URLs, endpoints e feature config
+- `public/data/cv.json` → fallback local de conteúdo
+- `TODO.md` → estado atual, pendências e orientação para continuidade
 
-- Small refactors, docs moves, keeping configs up-to-date
-- Adding/adjusting tests with Vitest (mocks for external services)
-- Maintaining Tailwind/shadcn patterns and routing consistency
+## Performance e 3D
+- Não quebrar performance com 3D: qualquer animação cara deve ser lazy-loaded.
+- Sempre implementar fallback visual para:
+  - dispositivos fracos
+  - `prefers-reduced-motion`
+  - falha de WebGL/WebGPU
+- Não aumentar densidade, luzes, partículas ou geometrias sem validar impacto em build e runtime.
+- Prefira backgrounds estáticos/degradados fora do caminho crítico inicial.
+- Antes de manter uma animação nova, valide se ela respeita LCP e loading inicial.
 
-## Safety checks
+## Dados dinâmicos
+- Evitar conteúdo totalmente estático quando houver valor real em dados dinâmicos.
+- GitHub deve preferir GraphQL quando houver token configurado; manter fallback REST/local.
+- Supabase deve continuar opcional: sempre tratar cliente indefinido e usar fallback em `cv.json`.
+- Não hardcodar APIs novas em componentes; centralizar em `src/config/site.ts` e `src/lib/`.
+- Toda nova fonte de dados precisa de loading state, estado degradado e tratamento de erro silencioso quando apropriado.
 
-- Keep changes small and scoped
-- Run build/tests/linters locally before opening PR
-- Don’t change `src/App.tsx`, `Layout.tsx`, `vite.config.ts` structure unless explicitly requested
-- For Supabase, always handle undefined client and fallback to cv.json
+## Branding e UX
+- Respeitar o equilíbrio entre portfólio pessoal e Monynha Softwares.
+- A assinatura visual desejada é: **Marcelo Santos / Monynha Softwares**.
+- Priorizar clareza de leitura, espaçamento consistente, responsividade perfeita e hierarquia visual forte.
+- Componentes reutilizáveis devem favorecer futura extração para `@monynha/ui`.
+- Não introduzir linguagem corporativa excessiva que apague o caráter pessoal do portfólio.
 
-See `.github/copilot-instructions.md` for the full architecture, data flow, and language/translation system overview.
+## Regras de qualidade
+- Manter tipagem forte e evitar soluções improvisadas.
+- Documentar mudanças estruturais e pendências no `TODO.md`.
+- Se alterar SEO, revisar title, description, canonical e OG/Twitter metadata.
+- Se alterar UX perceptível, tentar registrar screenshot; se a ferramenta não estiver disponível, documentar isso no resumo final.
+- Não alterar estrutura de `src/App.tsx`, `Layout.tsx` ou `vite.config.ts` sem necessidade real e justificada pela tarefa.
+- Não deixar integrações externas sem fallback.
+
+## O que não fazer
+- Não reativar 3D pesado em mobile por padrão.
+- Não depender exclusivamente de `cv.json` para recursos que podem ser dinâmicos.
+- Não hardcodar tokens, URLs sensíveis ou regras de negócio em componentes.
+- Não remover fallback estático/leve para animações, dados ou mídia.
+- Não esquecer de atualizar o `TODO.md` após mudanças relevantes.
+
+## Checklist final
+- [ ] Build executado com sucesso
+- [ ] Lint executado com sucesso
+- [ ] Testes executados com sucesso
+- [ ] Fallbacks preservados para 3D e dados
+- [ ] Branding Marcelo + Monynha revisado
+- [ ] SEO revisado se páginas principais foram tocadas
+- [ ] `TODO.md` atualizado
+- [ ] Mudanças prontas para continuidade por outro agente

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,55 @@
+# TODO
+
+## Estado atual
+- Home modularizada com code splitting por seções, hero otimizado e highlights dinâmicos do GitHub.
+- Background 3D agora respeita capacidade do dispositivo e `prefers-reduced-motion`, com fallback estático automático.
+- SEO técnico centralizado por hook, metadados base atualizados e configurações de GitHub/Supabase concentradas.
+- Projeto segue com fallback resiliente para `cv.json` e conteúdo local quando APIs externas falham.
+
+## O que foi concluído
+- Lazy loading aplicado às seções pesadas da Home e ao background 3D.
+- Redução de custo visual do `Galaxy` com densidade, velocidade e interações adaptativas.
+- Integração dinâmica com GitHub API adicionada com preferência por GraphQL e fallback REST/local.
+- Criação de `src/config/site.ts` para remover hardcodes centrais de branding e endpoints.
+- Hook `useSeoMetadata` criado para title, description, canonical, Open Graph e Twitter Cards.
+- Documentação operacional para agentes atualizada.
+
+## Pendências críticas
+- Revisar `src/main.tsx` e `src/App.tsx` para eliminar dupla composição de `QueryProvider` sem regressão.
+- Medir Core Web Vitals reais em produção (LCP, CLS e INP) com telemetria persistida.
+- Definir política segura para uso de token GitHub em produção e limites de rate limit.
+
+## Pendências importantes
+- Migrar mais páginas para seções/componentes reutilizáveis (`About`, `Contact`, detalhes de projeto).
+- Evoluir cards e layouts compartilhados visando futura extração para `@monynha/ui`.
+- Estruturar fetch dinâmico de contribuições GitHub e atividade recente por usuário/org.
+- Preparar estratégia híbrida Supabase + cache edge para conteúdo editorial.
+
+## Melhorias incrementais
+- Adicionar placeholders visuais específicos por seção além dos skeletons genéricos.
+- Incluir revalidação inteligente por visibilidade/tempo para dados externos.
+- Criar feature flag para desligar completamente 3D por ambiente.
+- Padronizar cópia institucional Monynha nos detalhes de projetos e páginas internas.
+
+## Bugs e limitações
+- Os testes passam, mas parte do suite emite erros de rede `ENETUNREACH` ao tocar serviços externos de tradução durante o ambiente isolado.
+- `vendor-three` continua grande, embora fique lazy-loaded e fora do caminho crítico inicial.
+- A integração GitHub GraphQL depende de `VITE_GITHUB_TOKEN`; sem token, a app cai para REST público/local fallback.
+
+## Próximos passos
+1. Instrumentar métricas reais de Web Vitals e exibir dashboard interno.
+2. Modularizar páginas restantes em `sections/` e `services/` dedicados.
+3. Criar camada `data adapters` para GitHub, Supabase e `cv.json` com contrato unificado.
+4. Adicionar testes para os novos fluxos de SEO e GitHub highlights.
+
+## Ideias futuras
+- Geração estática parcial de conteúdo de portfólio a partir de pipelines Monynha.
+- Personalização da Home por idioma/segmento profissional.
+- Feed vivo de changelog técnico e posts da Monynha.
+- Snapshot visual automatizado para regressão de UI.
+
+## Observações para o próximo agente
+- Não reative animações 3D pesadas sem fallback e sem medir impacto de LCP/INP.
+- Sempre usar `src/config/site.ts` para branding, URLs e integrações novas.
+- Se tocar dados dinâmicos, preservar fallback local e comportamento offline/degradado.
+- Atualize este arquivo ao concluir qualquer melhoria estrutural, técnica ou de produto.

--- a/index.html
+++ b/index.html
@@ -3,60 +3,49 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>Marcelo Santos - Software Engineer & Founder @ Monynha Softwares</title>
-    <meta name="description" content="Portfolio interativo de Marcelo Santos. Engenheiro de software, fundador da Monynha Softwares. Especialista em Next.js, Supabase, Flutter e DevOps." />
+    <title>Marcelo Santos — Product Engineer & Founder @ Monynha Softwares</title>
+    <meta
+      name="description"
+      content="Portfólio técnico de Marcelo Santos com foco em performance, branding Monynha Softwares, dados dinâmicos via GitHub e experiências digitais escaláveis."
+    />
     <meta name="author" content="Marcelo Santos" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#0f172a" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href="https://marcelo.monynha.com" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="dns-prefetch" href="https://api.github.com" />
+    <link rel="dns-prefetch" href="https://pkjigvacvddcnlxhvvba.supabase.co" />
+    <link rel="dns-prefetch" href="https://translate.googleapis.com" />
+    <link rel="prefetch" href="/data/cv.json" as="fetch" crossorigin="anonymous" />
+    <link rel="preload" href="/data/cv.json" as="fetch" crossorigin="anonymous" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap"
       rel="stylesheet"
-    >
-    
-    <!-- Prefetch critical data and assets -->
-    <link rel="prefetch" href="/data/cv.json" as="fetch" crossorigin="anonymous">
-    <link rel="dns-prefetch" href="https://pkjigvacvddcnlxhvvba.supabase.co">
-    <link rel="preconnect" href="https://pkjigvacvddcnlxhvvba.supabase.co">
-    <link rel="dns-prefetch" href="https://translate.googleapis.com">
-    
-    <!-- Performance hints -->
-    <link rel="preload" href="/data/cv.json" as="fetch" crossorigin="anonymous">
-    
-    <!-- Optimize font loading -->
-    <style>
-      /* Font display swap for faster initial render */
-      @font-face {
-        font-family: 'Inter';
-        font-display: swap;
-      }
-      @font-face {
-        font-family: 'JetBrains Mono';
-        font-display: swap;
-      }
-      @font-face {
-        font-family: 'Space Grotesk';
-        font-display: swap;
-      }
-    </style>
+    />
 
-    <meta property="og:title" content="Marcelo Santos - Portfolio" />
-    <meta property="og:description" content="Software Engineer & Founder @ Monynha Softwares. Especialista em desenvolvimento web, automação e DevOps." />
+    <meta property="og:site_name" content="MS-Portfolio" />
+    <meta property="og:title" content="Marcelo Santos — Monynha Softwares" />
+    <meta
+      property="og:description"
+      content="Portfólio técnico com produtos digitais, integrações dinâmicas e experiências criativas do ecossistema Monynha Softwares."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://marcelo.monynha.com" />
     <meta property="og:image" content="https://marcelo.monynha.com/og-image.svg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Marcelo Santos - Software Engineer & Founder @ Monynha Softwares" />
+    <meta property="og:image:alt" content="Marcelo Santos / Monynha Softwares" />
 
-    <meta name="instagram:card" content="summary_large_image" />
-    <meta name="instagram:site" content="@marcelo.santos.027" />
-    <meta name="instagram:title" content="Marcelo Santos - Portfolio" />
-    <meta name="instagram:description" content="Software Engineer & Founder @ Monynha Softwares" />
-    <meta name="instagram:image" content="https://marcelo.monynha.com/og-image.svg" />
-    <meta name="instagram:image:alt" content="Marcelo Santos - Software Engineer & Founder @ Monynha Softwares" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Marcelo Santos — Monynha Softwares" />
+    <meta
+      name="twitter:description"
+      content="Portfólio técnico com foco em performance, modularização e dados dinâmicos para o ecossistema Monynha Softwares."
+    />
+    <meta name="twitter:image" content="https://marcelo.monynha.com/og-image.svg" />
   </head>
-
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,43 +5,41 @@ import Footer from './Footer';
 import { LanguageMetadata } from './LanguageMetadata';
 import { useScrollToTop } from '@/hooks/useScrollToTop';
 import { useDeviceCapabilities } from '@/hooks/useDeviceCapabilities';
+import { StaticBackdrop } from '@/components/background/StaticBackdrop';
 
-// Lazy load Galaxy background for better performance
 const Galaxy = lazy(() => import('./Galaxy'));
 
 export default function Layout() {
   useScrollToTop();
-  // NOTE: We call the hook but ignore the result to force the background to render
-  // on all devices, overriding the performance optimization for low-end hardware.
-  useDeviceCapabilities(); 
+  const capabilities = useDeviceCapabilities();
 
   return (
-    <div className="relative flex flex-col min-h-[100dvh]">
+    <div className="relative flex min-h-[100dvh] flex-col">
       <LanguageMetadata />
-      {/* Galaxy Background - Forced visibility on all devices */}
-      <div className="block"> {/* Removed hidden md:block */}
-        <div className="fixed inset-0 w-full h-full -z-20"> {/* Changed z-index from z-10 back to -z-20 */}
-          <Suspense fallback={null}>
+      <div className="fixed inset-0 -z-20 h-full w-full">
+        {capabilities.shouldUseStaticExperience ? (
+          <StaticBackdrop />
+        ) : (
+          <Suspense fallback={<StaticBackdrop />}>
             <Galaxy
-              mouseInteraction={true}
-              mouseRepulsion={true}
-              density={1}
-              glowIntensity={0.3}
-              saturation={0.5}
+              mouseInteraction={!capabilities.prefersReducedMotion}
+              mouseRepulsion={!capabilities.prefersReducedMotion}
+              density={capabilities.hasDiscreteGPU ? 1 : 0.72}
+              glowIntensity={capabilities.hasDiscreteGPU ? 0.28 : 0.18}
+              saturation={0.45}
               hueShift={200}
-              twinkleIntensity={0.8}
-              rotationSpeed={0.01}
-              repulsionStrength={2}
+              twinkleIntensity={capabilities.hasDiscreteGPU ? 0.55 : 0.32}
+              rotationSpeed={capabilities.hasDiscreteGPU ? 0.01 : 0.004}
+              repulsionStrength={capabilities.hasDiscreteGPU ? 1.6 : 1}
               autoCenterRepulsion={0}
-              starSpeed={0.3}
-              speed={1}
+              starSpeed={capabilities.hasDiscreteGPU ? 0.22 : 0.16}
+              speed={capabilities.hasDiscreteGPU ? 0.75 : 0.55}
             />
           </Suspense>
-        </div>
+        )}
       </div>
-      
       <Navbar />
-      <main className="flex-grow pt-24 pb-16 relative z-0">
+      <main className="relative z-0 flex-grow pb-16 pt-24">
         <Outlet />
       </main>
       <Footer />

--- a/src/components/background/StaticBackdrop.tsx
+++ b/src/components/background/StaticBackdrop.tsx
@@ -1,0 +1,11 @@
+export function StaticBackdrop() {
+  return (
+    <div
+      aria-hidden
+      className="absolute inset-0 overflow-hidden bg-[radial-gradient(circle_at_top,_hsl(var(--secondary)/0.18),_transparent_38%),radial-gradient(circle_at_80%_20%,_hsl(var(--accent)/0.16),_transparent_28%),linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--background)))]"
+    >
+      <div className="absolute inset-x-0 top-0 h-64 bg-gradient-to-b from-primary/10 via-secondary/5 to-transparent blur-3xl" />
+      <div className="absolute left-1/2 top-24 h-40 w-40 -translate-x-1/2 rounded-full border border-primary/10 bg-primary/5 blur-2xl" />
+    </div>
+  );
+}

--- a/src/components/sections/home/FeaturedProjectsSection.tsx
+++ b/src/components/sections/home/FeaturedProjectsSection.tsx
@@ -1,0 +1,93 @@
+import { memo, useMemo } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowRight, Code2 } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface FeaturedProject {
+  slug: string;
+  name: string;
+  summary: string;
+  category: string;
+  year: number;
+  technologies?: Array<{ name: string }>;
+}
+
+const FeaturedProjectCard = memo(function FeaturedProjectCard({ project, index }: { project: FeaturedProject; index: number }) {
+  const prefersReducedMotion = useReducedMotion();
+  const techStack = useMemo(() => (project.technologies?.map((item) => item.name) ?? []).slice(0, 3), [project.technologies]);
+
+  return (
+    <motion.div
+      initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+      whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: '-60px' }}
+      transition={{ delay: index * 0.08, duration: 0.45 }}
+      className="group"
+    >
+      <Link to={`/portfolio/${project.slug}`} className="block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background">
+        <div className="h-full rounded-2xl border border-border/70 bg-card/70 p-6 shadow-md transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-lg">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/80 via-secondary/70 to-accent/70 text-white shadow-md">
+              <Code2 className="h-6 w-6" aria-hidden />
+            </div>
+            <div className="flex flex-col items-end gap-2 text-xs">
+              <span className="rounded-full bg-muted px-3 py-1 text-muted-foreground">{project.category}</span>
+              <span className="rounded-full border border-border/60 bg-background/70 px-3 py-1 text-muted-foreground">{project.year}</span>
+            </div>
+          </div>
+          <h3 className="text-xl font-bold transition-colors group-hover:text-primary">{project.name}</h3>
+          <p className="mt-3 text-sm text-muted-foreground">{project.summary}</p>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {techStack.map((tech) => (
+              <span key={tech} className="rounded-xl bg-muted/60 px-3 py-1 text-xs text-foreground/80">{tech}</span>
+            ))}
+          </div>
+        </div>
+      </Link>
+    </motion.div>
+  );
+});
+
+export const FeaturedProjectsSection = memo(function FeaturedProjectsSection({
+  loading,
+  projects,
+  title,
+  subtitle,
+  ctaLabel,
+}: {
+  loading: boolean;
+  projects: FeaturedProject[];
+  title: string;
+  subtitle: string;
+  ctaLabel: string;
+}) {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <section className="px-6 py-24">
+      <div className="container mx-auto max-w-7xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+          whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="mb-16 text-center"
+        >
+          <h2 className="text-4xl font-bold md:text-5xl">{title}</h2>
+          <p className="mx-auto mt-5 max-w-2xl text-lg text-muted-foreground">{subtitle}</p>
+        </motion.div>
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {loading
+            ? Array.from({ length: 3 }).map((_, index) => <Skeleton key={index} className="h-40 w-full rounded-2xl" />)
+            : projects.map((project, index) => <FeaturedProjectCard key={project.slug} project={project} index={index} />)}
+        </div>
+        <motion.div initial={prefersReducedMotion ? undefined : { opacity: 0 }} whileInView={prefersReducedMotion ? undefined : { opacity: 1 }} viewport={{ once: true }} className="mt-12 text-center">
+          <Button asChild variant="outline" size="lg" className="border-border/70">
+            <Link to="/portfolio">{ctaLabel}<ArrowRight className="ml-2 h-4 w-4" /></Link>
+          </Button>
+        </motion.div>
+      </div>
+    </section>
+  );
+});

--- a/src/components/sections/home/GitHubHighlightsSection.tsx
+++ b/src/components/sections/home/GitHubHighlightsSection.tsx
@@ -1,0 +1,85 @@
+import { memo } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowUpRight, GitBranch, Star } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { siteConfig } from '@/config/site';
+
+export interface GitHubHighlightItem {
+  id: string;
+  name: string;
+  description: string;
+  url: string;
+  stars: number;
+  forks: number;
+  updatedAt: string;
+  language: string | null;
+}
+
+export const GitHubHighlightsSection = memo(function GitHubHighlightsSection({
+  items,
+  isLoading,
+  isFallback,
+}: {
+  items: GitHubHighlightItem[];
+  isLoading: boolean;
+  isFallback: boolean;
+}) {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <section className="px-6 pb-24">
+      <div className="container mx-auto max-w-7xl rounded-[2rem] border border-border/60 bg-card/70 p-8 shadow-[0_35px_90px_-70px_hsl(var(--secondary)/0.45)] backdrop-blur-xl md:p-10">
+        <motion.div initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }} whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }} viewport={{ once: true }} className="mb-10 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-secondary">GitHub dinâmico</p>
+            <h2 className="mt-3 text-3xl font-bold md:text-4xl">Repos e atividade recente da Monynha</h2>
+            <p className="mt-4 max-w-2xl text-muted-foreground">
+              Dados carregados via GitHub API com preferência por GraphQL, mantendo fallback local para preservar resiliência e previsibilidade visual.
+            </p>
+          </div>
+          <Button asChild variant="outline" className="border-border/70 md:self-start">
+            <a href={`https://github.com/${siteConfig.github.organization}`} target="_blank" rel="noopener noreferrer">Ver organização<ArrowUpRight className="ml-2 h-4 w-4" /></a>
+          </Button>
+        </motion.div>
+
+        {isFallback && !isLoading ? (
+          <div className="mb-6 rounded-2xl border border-dashed border-border/70 bg-background/40 px-4 py-3 text-sm text-muted-foreground">
+            Exibindo fallback local porque a API do GitHub não respondeu ou excedeu limite de uso.
+          </div>
+        ) : null}
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          {isLoading
+            ? Array.from({ length: 3 }).map((_, index) => <Skeleton key={index} className="h-48 w-full rounded-2xl" />)
+            : items.map((item, index) => (
+                <motion.a
+                  key={item.id}
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  initial={prefersReducedMotion ? undefined : { opacity: 0, y: 16 }}
+                  whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: index * 0.08 }}
+                  className="group rounded-2xl border border-border/60 bg-background/60 p-6 transition hover:-translate-y-1 hover:shadow-lg"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h3 className="text-xl font-semibold group-hover:text-primary">{item.name}</h3>
+                      <p className="mt-3 line-clamp-3 text-sm leading-6 text-muted-foreground">{item.description}</p>
+                    </div>
+                    <ArrowUpRight className="h-5 w-5 text-muted-foreground transition group-hover:text-primary" />
+                  </div>
+                  <div className="mt-6 flex flex-wrap gap-4 text-sm text-muted-foreground">
+                    <span className="inline-flex items-center gap-2"><Star className="h-4 w-4" />{item.stars}</span>
+                    <span className="inline-flex items-center gap-2"><GitBranch className="h-4 w-4" />{item.forks}</span>
+                    <span>{item.language ?? 'Multistack'}</span>
+                  </div>
+                </motion.a>
+              ))}
+        </div>
+      </div>
+    </section>
+  );
+});

--- a/src/components/sections/home/HeroSection.tsx
+++ b/src/components/sections/home/HeroSection.tsx
@@ -1,0 +1,115 @@
+import { memo, useMemo } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowRight, Code2, Globe, Sparkles } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { LINKS } from '@/lib/siteLinks';
+import { siteConfig } from '@/config/site';
+
+interface HeroSectionProps {
+  loadingProfile: boolean;
+  location?: string;
+  name?: string;
+  headline?: string;
+  bio?: string;
+  exploreLabel: string;
+  contactLabel: string;
+}
+
+export const HeroSection = memo(function HeroSection({
+  loadingProfile,
+  location,
+  name,
+  headline,
+  bio,
+  exploreLabel,
+  contactLabel,
+}: HeroSectionProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const containerVariants = useMemo(
+    () => ({
+      hidden: { opacity: 0 },
+      visible: { opacity: 1, transition: { staggerChildren: 0.1 } },
+    }),
+    [],
+  );
+
+  const itemVariants = useMemo(
+    () => ({
+      hidden: { opacity: 0, y: 20 },
+      visible: { opacity: 1, y: 0 },
+    }),
+    [],
+  );
+
+  return (
+    <section className="relative min-h-[calc(100dvh-8rem)] overflow-hidden py-16">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_hsl(var(--secondary)/0.14),_transparent_34%),radial-gradient(circle_at_80%_20%,_hsl(var(--accent)/0.12),_transparent_26%)]" />
+      <div className="container relative z-10 mx-auto flex min-h-[calc(100dvh-8rem)] items-center px-6">
+        <motion.div
+          variants={containerVariants}
+          initial={prefersReducedMotion ? undefined : 'hidden'}
+          animate={prefersReducedMotion ? undefined : 'visible'}
+          className="mx-auto grid max-w-6xl items-center gap-16 lg:grid-cols-[minmax(0,1.3fr)_minmax(320px,0.7fr)]"
+        >
+          <div className="text-center lg:text-left">
+            <motion.div variants={itemVariants} className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/70 px-4 py-2 shadow-sm">
+              <Sparkles className="h-4 w-4 text-accent" />
+              {loadingProfile ? <Skeleton className="h-4 w-24" /> : <span className="text-sm font-medium">{location}</span>}
+            </motion.div>
+
+            <motion.p variants={itemVariants} className="mt-6 text-sm font-semibold uppercase tracking-[0.22em] text-secondary">
+              {siteConfig.brand.accentLabel}
+            </motion.p>
+
+            <motion.h1 variants={itemVariants} className="mt-4 text-balance text-5xl font-bold md:text-7xl">
+              <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
+                {loadingProfile ? <span className="inline-block h-10 w-40 rounded-md bg-muted" aria-hidden /> : name}
+              </span>
+            </motion.h1>
+
+            <motion.p variants={itemVariants} className="mt-6 text-xl font-medium text-muted-foreground md:text-2xl">
+              {loadingProfile ? <span className="inline-block h-6 w-72 rounded-md bg-muted" aria-hidden /> : headline}
+            </motion.p>
+
+            <motion.p variants={itemVariants} className="mt-6 max-w-3xl text-lg leading-8 text-muted-foreground/85 lg:max-w-2xl">
+              {loadingProfile ? <span className="inline-block h-5 w-80 rounded-md bg-muted" aria-hidden /> : bio}
+            </motion.p>
+
+            <motion.div variants={itemVariants} className="mt-10 flex flex-col gap-4 sm:flex-row sm:flex-wrap lg:justify-start justify-center">
+              <Button asChild size="lg" className="px-8 shadow-lg shadow-secondary/20">
+                <Link to="/portfolio"><Code2 className="mr-2 h-4 w-4" />{exploreLabel}<ArrowRight className="ml-2 h-4 w-4" /></Link>
+              </Button>
+              <Button asChild variant="outline" size="lg" className="border-border/70 bg-card/60 px-8">
+                <Link to="/contact">{contactLabel}</Link>
+              </Button>
+              <Button asChild variant="secondary" size="lg" className="px-8 shadow-lg shadow-accent/20">
+                <a href={LINKS.monynhaSite} target="_blank" rel="noopener noreferrer"><Globe className="mr-2 h-4 w-4" />Monynha Softwares<ArrowRight className="ml-2 h-4 w-4" /></a>
+              </Button>
+            </motion.div>
+          </div>
+
+          <motion.aside variants={itemVariants} className="rounded-3xl border border-border/60 bg-card/75 p-6 text-left shadow-[0_30px_80px_-60px_hsl(var(--primary)/0.45)] backdrop-blur-xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-secondary">Assinatura</p>
+            <h2 className="mt-4 text-2xl font-semibold text-foreground">{siteConfig.signature}</h2>
+            <p className="mt-4 text-sm leading-7 text-muted-foreground">
+              Produto pessoal com arquitetura pensada para reaproveitamento no ecossistema Monynha, combinando branding institucional, experimentação criativa e foco rigoroso em performance.
+            </p>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl border border-border/50 bg-background/60 p-4">
+                <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Foco</p>
+                <p className="mt-2 text-sm font-medium">Performance, dados dinâmicos e UX confiável</p>
+              </div>
+              <div className="rounded-2xl border border-border/50 bg-background/60 p-4">
+                <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Base</p>
+                <p className="mt-2 text-sm font-medium">Vite + React + TypeScript + Tailwind + shadcn/ui</p>
+              </div>
+            </div>
+          </motion.aside>
+        </motion.div>
+      </div>
+    </section>
+  );
+});

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,37 @@
+export const siteConfig = {
+  siteName: 'MS-Portfolio',
+  ownerName: 'Marcelo Santos',
+  signature: 'Marcelo Santos / Monynha Softwares',
+  title: 'Marcelo Santos — Product Engineer & Founder @ Monynha Softwares',
+  shortTitle: 'Marcelo Santos — Monynha Softwares',
+  description:
+    'Portfólio técnico de Marcelo Santos com produtos digitais, experiências criativas, integrações dinâmicas com GitHub e arquitetura preparada para o ecossistema Monynha Softwares.',
+  url: 'https://marcelo.monynha.com',
+  ogImage: 'https://marcelo.monynha.com/og-image.svg',
+  github: {
+    username: import.meta.env.VITE_GITHUB_USERNAME || 'marcelo-m7',
+    organization: import.meta.env.VITE_GITHUB_ORG || 'Monynha-Softwares',
+    token: import.meta.env.VITE_GITHUB_TOKEN,
+    graphQlEndpoint: import.meta.env.VITE_GITHUB_GRAPHQL_ENDPOINT || 'https://api.github.com/graphql',
+    restEndpoint: import.meta.env.VITE_GITHUB_REST_ENDPOINT || 'https://api.github.com',
+    featuredFallback: [
+      'MS-Portfolio',
+      'Monynha-com',
+      'MonaDocs',
+      'BotecoPro',
+    ],
+  },
+  supabase: {
+    url: import.meta.env.VITE_SUPABASE_URL,
+    schema: import.meta.env.VITE_SUPABASE_SCHEMA || 'portfolio',
+  },
+  brand: {
+    accentLabel: 'Powered by Monynha Softwares',
+    palette: ['primary', 'secondary', 'accent'] as const,
+  },
+} as const;
+
+export function buildAbsoluteUrl(pathname = ''): string {
+  if (!pathname) return siteConfig.url;
+  return new URL(pathname, siteConfig.url).toString();
+}

--- a/src/hooks/useDeviceCapabilities.ts
+++ b/src/hooks/useDeviceCapabilities.ts
@@ -1,112 +1,82 @@
 /**
- * Hook to detect device capabilities for performance optimization
- * Helps decide whether to enable expensive features like 3D backgrounds
+ * Hook to detect device capabilities for performance optimization.
+ * Keeps 3D disabled by default until a device proves it can handle heavier rendering.
  */
 
 import { useEffect, useState } from 'react';
 
-// Breakpoint for mobile detection (in pixels)
 const MOBILE_BREAKPOINT = 768;
-
-// Performance thresholds
 const MIN_DEVICE_MEMORY_GB = 4;
 const MIN_CPU_CORES = 4;
 
 interface DeviceCapabilities {
-  /** Whether the device can handle heavy 3D graphics */
   canHandle3D: boolean;
-  /** Whether the device has a discrete GPU */
   hasDiscreteGPU: boolean;
-  /** Device memory in GB (if available) */
   deviceMemory?: number;
-  /** Number of logical CPU cores */
   hardwareConcurrency?: number;
-  /** Whether user prefers reduced data usage */
   saveData: boolean;
+  prefersReducedMotion: boolean;
+  shouldUseStaticExperience: boolean;
 }
 
-/**
- * Detect device capabilities for performance optimization
- */
 export function useDeviceCapabilities(): DeviceCapabilities {
-  const [capabilities, setCapabilities] = useState<DeviceCapabilities>(() => {
-    // Initial values (conservative defaults)
-    return {
-      canHandle3D: true, // Assume capable initially
-      hasDiscreteGPU: false,
-      saveData: false,
-    };
+  const [capabilities, setCapabilities] = useState<DeviceCapabilities>({
+    canHandle3D: false,
+    hasDiscreteGPU: false,
+    saveData: false,
+    prefersReducedMotion: false,
+    shouldUseStaticExperience: true,
   });
 
   useEffect(() => {
-    // Only run detection in browser
-    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-      return;
-    }
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') return;
 
     async function detectCapabilities() {
-      // Check for save-data preference
-      const connection = (navigator as Navigator & {
-        connection?: { saveData?: boolean; effectiveType?: string };
-      }).connection;
+      const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+      const connection = (navigator as Navigator & { connection?: { saveData?: boolean; effectiveType?: string } }).connection;
       const saveData = connection?.saveData || false;
       const effectiveType = connection?.effectiveType;
-
-      // Check device memory (Chrome/Edge only)
-      const deviceMemory = (navigator as Navigator & {
-        deviceMemory?: number;
-      }).deviceMemory;
-
-      // Check hardware concurrency (number of logical processors)
+      const deviceMemory = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
       const hardwareConcurrency = navigator.hardwareConcurrency;
 
-      // Check for WebGL capabilities
       let hasDiscreteGPU = false;
-      let canHandle3D = true;
+      let webGlAvailable = true;
 
       try {
         const canvas = document.createElement('canvas');
         const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
-        
-        if (gl) {
+        if (!gl) {
+          webGlAvailable = false;
+        } else {
           const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
           if (debugInfo) {
-            const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
-            const vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
-            
-            // Check for discrete GPU indicators
-            const rendererLower = String(renderer).toLowerCase();
-            hasDiscreteGPU = 
-              rendererLower.includes('nvidia') ||
-              rendererLower.includes('amd') ||
-              rendererLower.includes('radeon') ||
-              rendererLower.includes('geforce') ||
-              (rendererLower.includes('intel') && rendererLower.includes('iris'));
+            const renderer = String(gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)).toLowerCase();
+            hasDiscreteGPU =
+              renderer.includes('nvidia') ||
+              renderer.includes('amd') ||
+              renderer.includes('radeon') ||
+              renderer.includes('geforce') ||
+              (renderer.includes('intel') && renderer.includes('iris'));
           }
         }
-      } catch (error) {
-        console.warn('Failed to detect GPU capabilities:', error);
-        canHandle3D = false;
+      } catch {
+        webGlAvailable = false;
       }
 
-      // Decision logic for 3D support
-      // Disable 3D if:
-      // 1. User has save-data enabled
-      // 2. Connection is slow (2g/slow-2g)
-      // 3. Device has low memory (< 4GB)
-      // 4. Device has few CPU cores (< 4)
-      // 5. Mobile device (detected by screen width)
       const isMobile = window.innerWidth < MOBILE_BREAKPOINT;
-      const hasLowMemory = deviceMemory && deviceMemory < MIN_DEVICE_MEMORY_GB;
-      const hasFewCores = hardwareConcurrency && hardwareConcurrency < MIN_CPU_CORES;
+      const hasLowMemory = typeof deviceMemory === 'number' && deviceMemory < MIN_DEVICE_MEMORY_GB;
+      const hasFewCores = typeof hardwareConcurrency === 'number' && hardwareConcurrency < MIN_CPU_CORES;
       const hasSlowConnection = effectiveType === '2g' || effectiveType === 'slow-2g';
 
-      canHandle3D = canHandle3D && 
-        !saveData && 
-        !hasSlowConnection && 
-        !hasLowMemory &&
-        !hasFewCores &&
-        !isMobile;
+      const canHandle3D = Boolean(
+        webGlAvailable &&
+          !reducedMotion &&
+          !saveData &&
+          !hasSlowConnection &&
+          !hasLowMemory &&
+          !hasFewCores &&
+          !isMobile,
+      );
 
       setCapabilities({
         canHandle3D,
@@ -114,19 +84,14 @@ export function useDeviceCapabilities(): DeviceCapabilities {
         deviceMemory,
         hardwareConcurrency,
         saveData,
+        prefersReducedMotion: reducedMotion,
+        shouldUseStaticExperience: !canHandle3D,
       });
     }
 
     detectCapabilities();
-
-    // Re-check all capabilities on resize (not just mobile status)
-    const handleResize = () => {
-      // Re-run full detection to re-evaluate all factors
-      detectCapabilities();
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener('resize', detectCapabilities);
+    return () => window.removeEventListener('resize', detectCapabilities);
   }, []);
 
   return capabilities;

--- a/src/hooks/useGitHubStats.ts
+++ b/src/hooks/useGitHubStats.ts
@@ -1,19 +1,18 @@
 /**
- * React Query hooks for GitHub repository statistics
+ * React Query hooks for GitHub repository statistics and highlighted activity.
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { fetchGitHubRepoStats, fetchMultipleRepoStats, type GitHubRepoStats } from '@/lib/githubApi';
+import {
+  fetchGitHubRepoStats,
+  fetchHighlightedRepos,
+  fetchMultipleRepoStats,
+  type GitHubRepoStats,
+} from '@/lib/githubApi';
 
-// Cache GitHub stats for 30 minutes (GitHub API has rate limits)
 const GITHUB_STALE_TIME = 30 * 60 * 1000;
-const GITHUB_CACHE_TIME = 60 * 60 * 1000; // 1 hour
+const GITHUB_CACHE_TIME = 60 * 60 * 1000;
 
-/**
- * Hook to fetch GitHub repository statistics for a single repo
- * @param repoUrl - Full GitHub repository URL
- * @param enabled - Whether to enable the query (default: true)
- */
 export function useGitHubRepoStats(repoUrl: string | null | undefined, enabled = true) {
   return useQuery({
     queryKey: ['github-repo-stats', repoUrl],
@@ -24,15 +23,10 @@ export function useGitHubRepoStats(repoUrl: string | null | undefined, enabled =
     enabled: enabled && !!repoUrl,
     staleTime: GITHUB_STALE_TIME,
     gcTime: GITHUB_CACHE_TIME,
-    retry: 1, // Only retry once for GitHub API
+    retry: 1,
   });
 }
 
-/**
- * Hook to fetch GitHub statistics for multiple repositories
- * @param repoUrls - Array of GitHub repository URLs
- * @param enabled - Whether to enable the query (default: true)
- */
 export function useMultipleGitHubRepoStats(repoUrls: string[], enabled = true) {
   return useQuery({
     queryKey: ['github-multi-stats', repoUrls.sort().join(',')],
@@ -43,3 +37,16 @@ export function useMultipleGitHubRepoStats(repoUrls: string[], enabled = true) {
     retry: 1,
   });
 }
+
+export function useGitHubHighlights(enabled = true) {
+  return useQuery({
+    queryKey: ['github-highlights'],
+    queryFn: fetchHighlightedRepos,
+    enabled,
+    staleTime: GITHUB_STALE_TIME,
+    gcTime: GITHUB_CACHE_TIME,
+    retry: 1,
+  });
+}
+
+export type { GitHubRepoStats };

--- a/src/hooks/useSeoMetadata.ts
+++ b/src/hooks/useSeoMetadata.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { buildAbsoluteUrl, siteConfig } from '@/config/site';
+
+interface SeoMetadataOptions {
+  title: string;
+  description: string;
+  path?: string;
+  image?: string;
+}
+
+function upsertMeta(selector: string, attributes: Record<string, string>) {
+  let element = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!element) {
+    element = document.createElement('meta');
+    document.head.appendChild(element);
+  }
+
+  Object.entries(attributes).forEach(([key, value]) => {
+    element?.setAttribute(key, value);
+  });
+}
+
+export function useSeoMetadata({ title, description, path = '/', image = siteConfig.ogImage }: SeoMetadataOptions) {
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    document.title = title;
+
+    upsertMeta('meta[name="description"]', { name: 'description', content: description });
+    upsertMeta('meta[property="og:title"]', { property: 'og:title', content: title });
+    upsertMeta('meta[property="og:description"]', { property: 'og:description', content: description });
+    upsertMeta('meta[property="og:url"]', { property: 'og:url', content: buildAbsoluteUrl(path) });
+    upsertMeta('meta[property="og:image"]', { property: 'og:image', content: image });
+    upsertMeta('meta[name="twitter:card"]', { name: 'twitter:card', content: 'summary_large_image' });
+    upsertMeta('meta[name="twitter:title"]', { name: 'twitter:title', content: title });
+    upsertMeta('meta[name="twitter:description"]', { name: 'twitter:description', content: description });
+    upsertMeta('meta[name="twitter:image"]', { name: 'twitter:image', content: image });
+    upsertMeta('meta[name="theme-color"]', { name: 'theme-color', content: '#0f172a' });
+
+    let canonical = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    if (!canonical) {
+      canonical = document.createElement('link');
+      canonical.rel = 'canonical';
+      document.head.appendChild(canonical);
+    }
+    canonical.href = buildAbsoluteUrl(path);
+  }, [description, image, path, title]);
+}

--- a/src/lib/githubApi.ts
+++ b/src/lib/githubApi.ts
@@ -1,7 +1,8 @@
 /**
- * GitHub API integration for fetching repository statistics
- * Uses GitHub REST API v3 (no authentication required for public repos)
+ * GitHub API integration for fetching repository statistics and dynamic portfolio highlights.
+ * Prefers GitHub GraphQL when a token is available, with REST and local fallbacks for resilience.
  */
+import { siteConfig } from '@/config/site';
 import { logger } from './logger';
 
 export interface GitHubRepoStats {
@@ -15,62 +16,181 @@ export interface GitHubRepoStats {
   description: string | null;
 }
 
-/**
- * Extract owner and repo name from a GitHub URL
- * @example extractRepoInfo('https://github.com/owner/repo') // { owner: 'owner', repo: 'repo' }
- */
+export interface GitHubHighlightedRepo {
+  id: string;
+  name: string;
+  description: string;
+  url: string;
+  stars: number;
+  forks: number;
+  updatedAt: string;
+  language: string | null;
+}
+
+interface GitHubGraphQlRepoNode {
+  id: string;
+  name: string;
+  description: string | null;
+  url: string;
+  stargazerCount: number;
+  forkCount: number;
+  updatedAt: string;
+  primaryLanguage: { name: string } | null;
+}
+
+function getGitHubHeaders(useGraphQl = false): HeadersInit {
+  return {
+    Accept: useGraphQl ? 'application/vnd.github+json' : 'application/vnd.github.v3+json',
+    ...(siteConfig.github.token ? { Authorization: `Bearer ${siteConfig.github.token}` } : {}),
+  };
+}
+
+function mapRepoNode(node: GitHubGraphQlRepoNode): GitHubHighlightedRepo {
+  return {
+    id: node.id,
+    name: node.name,
+    description: node.description ?? 'Repositório estratégico do ecossistema Monynha.',
+    url: node.url,
+    stars: node.stargazerCount,
+    forks: node.forkCount,
+    updatedAt: node.updatedAt,
+    language: node.primaryLanguage?.name ?? null,
+  };
+}
+
 function extractRepoInfo(githubUrl: string): { owner: string; repo: string } | null {
   try {
     const url = new URL(githubUrl);
-    if (url.hostname !== 'github.com') {
-      return null;
-    }
-    
+    if (url.hostname !== 'github.com') return null;
     const parts = url.pathname.split('/').filter(Boolean);
-    if (parts.length < 2) {
-      return null;
-    }
-    
-    return {
-      owner: parts[0],
-      repo: parts[1],
-    };
+    if (parts.length < 2) return null;
+    return { owner: parts[0], repo: parts[1] };
   } catch {
     return null;
   }
 }
 
-/**
- * Fetch repository statistics from GitHub API
- * Uses public API (no auth required) with rate limiting considerations
- */
-export async function fetchGitHubRepoStats(repoUrl: string): Promise<GitHubRepoStats | null> {
-  const repoInfo = extractRepoInfo(repoUrl);
-  if (!repoInfo) {
-    return null;
-  }
+async function fetchGraphQlHighlightedRepos(): Promise<GitHubHighlightedRepo[] | null> {
+  if (!siteConfig.github.token) return null;
 
-  const { owner, repo } = repoInfo;
-  const apiUrl = `https://api.github.com/repos/${owner}/${repo}`;
+  const query = `
+    query PortfolioHighlights($login: String!, $fallback: String!, $limit: Int!) {
+      organization(login: $login) {
+        repositories(first: $limit, orderBy: {field: PUSHED_AT, direction: DESC}, privacy: PUBLIC, isFork: false) {
+          nodes { id name description url stargazerCount forkCount updatedAt primaryLanguage { name } }
+        }
+      }
+      user(login: $fallback) {
+        repositories(first: $limit, orderBy: {field: PUSHED_AT, direction: DESC}, privacy: PUBLIC, isFork: false) {
+          nodes { id name description url stargazerCount forkCount updatedAt primaryLanguage { name } }
+        }
+      }
+    }
+  `;
 
   try {
-    const response = await fetch(apiUrl, {
+    const response = await fetch(siteConfig.github.graphQlEndpoint, {
+      method: 'POST',
       headers: {
-        Accept: 'application/vnd.github.v3+json',
-        // Optional: Add GitHub token via env var for higher rate limits
-        ...(import.meta.env.VITE_GITHUB_TOKEN
-          ? { Authorization: `Bearer ${import.meta.env.VITE_GITHUB_TOKEN}` }
-          : {}),
+        'Content-Type': 'application/json',
+        ...getGitHubHeaders(true),
       },
+      body: JSON.stringify({
+        query,
+        variables: {
+          login: siteConfig.github.organization,
+          fallback: siteConfig.github.username,
+          limit: 6,
+        },
+      }),
     });
+
+    if (!response.ok) {
+      logger.warn('GitHub GraphQL request failed', { component: 'githubApi', status: response.status });
+      return null;
+    }
+
+    const payload = await response.json();
+    const orgNodes = payload?.data?.organization?.repositories?.nodes as GitHubGraphQlRepoNode[] | undefined;
+    const userNodes = payload?.data?.user?.repositories?.nodes as GitHubGraphQlRepoNode[] | undefined;
+    const repos = [...(orgNodes ?? []), ...(userNodes ?? [])].filter(Boolean).slice(0, 6).map(mapRepoNode);
+    return repos.length > 0 ? repos : null;
+  } catch (error) {
+    logger.error('Error fetching GraphQL GitHub highlights', { component: 'githubApi' }, error);
+    return null;
+  }
+}
+
+async function fetchRestHighlightedRepos(): Promise<GitHubHighlightedRepo[] | null> {
+  const candidates = [siteConfig.github.organization, siteConfig.github.username];
+
+  for (const account of candidates) {
+    try {
+      const response = await fetch(`${siteConfig.github.restEndpoint}/users/${account}/repos?sort=pushed&per_page=6&type=owner`, {
+        headers: getGitHubHeaders(),
+      });
+
+      if (!response.ok) continue;
+      const data = await response.json();
+      const repos = (Array.isArray(data) ? data : [])
+        .filter((repo) => !repo.fork)
+        .slice(0, 6)
+        .map((repo) => ({
+          id: String(repo.id),
+          name: repo.name,
+          description: repo.description ?? 'Repositório estratégico do ecossistema Monynha.',
+          url: repo.html_url,
+          stars: repo.stargazers_count ?? 0,
+          forks: repo.forks_count ?? 0,
+          updatedAt: repo.updated_at ?? repo.pushed_at ?? '',
+          language: repo.language ?? null,
+        }));
+
+      if (repos.length > 0) return repos;
+    } catch (error) {
+      logger.error('Error fetching REST GitHub highlights', { component: 'githubApi', account }, error);
+    }
+  }
+
+  return null;
+}
+
+export async function fetchHighlightedRepos(): Promise<{ items: GitHubHighlightedRepo[]; isFallback: boolean }> {
+  const graphQlRepos = await fetchGraphQlHighlightedRepos();
+  if (graphQlRepos) return { items: graphQlRepos, isFallback: false };
+
+  const restRepos = await fetchRestHighlightedRepos();
+  if (restRepos) return { items: restRepos, isFallback: false };
+
+  const fallbackItems = siteConfig.github.featuredFallback.map((name, index) => ({
+    id: `fallback-${name}-${index}`,
+    name,
+    description: 'Fallback local para preservar estabilidade visual enquanto a integração dinâmica estiver indisponível.',
+    url: `https://github.com/${siteConfig.github.organization}/${name}`,
+    stars: 0,
+    forks: 0,
+    updatedAt: '',
+    language: null,
+  }));
+
+  return { items: fallbackItems, isFallback: true };
+}
+
+export async function fetchGitHubRepoStats(repoUrl: string): Promise<GitHubRepoStats | null> {
+  const repoInfo = extractRepoInfo(repoUrl);
+  if (!repoInfo) return null;
+
+  const { owner, repo } = repoInfo;
+  const apiUrl = `${siteConfig.github.restEndpoint}/repos/${owner}/${repo}`;
+
+  try {
+    const response = await fetch(apiUrl, { headers: getGitHubHeaders() });
 
     if (!response.ok) {
       if (response.status === 404) {
         logger.warn(`GitHub repository not found: ${repoUrl}`, { component: 'githubApi' });
       } else if (response.status === 403) {
-        logger.warn('GitHub API rate limit exceeded. Consider adding VITE_GITHUB_TOKEN.', {
-          component: 'githubApi',
-        });
+        logger.warn('GitHub API rate limit exceeded. Consider adding VITE_GITHUB_TOKEN.', { component: 'githubApi' });
       }
       return null;
     }
@@ -93,55 +213,27 @@ export async function fetchGitHubRepoStats(repoUrl: string): Promise<GitHubRepoS
   }
 }
 
-/**
- * Fetch multiple repository stats in parallel
- * Useful for portfolio pages with multiple projects
- */
-export async function fetchMultipleRepoStats(
-  repoUrls: string[]
-): Promise<Map<string, GitHubRepoStats>> {
-  const results = await Promise.allSettled(
-    repoUrls.map(async (url) => ({
-      url,
-      stats: await fetchGitHubRepoStats(url),
-    }))
-  );
-
+export async function fetchMultipleRepoStats(repoUrls: string[]): Promise<Map<string, GitHubRepoStats>> {
+  const results = await Promise.allSettled(repoUrls.map(async (url) => ({ url, stats: await fetchGitHubRepoStats(url) })));
   const statsMap = new Map<string, GitHubRepoStats>();
-  
   results.forEach((result) => {
-    if (result.status === 'fulfilled' && result.value.stats) {
-      statsMap.set(result.value.url, result.value.stats);
-    }
+    if (result.status === 'fulfilled' && result.value.stats) statsMap.set(result.value.url, result.value.stats);
   });
-
   return statsMap;
 }
 
-/**
- * Format star count for display (e.g., 1500 -> "1.5k", 1500000 -> "1.5M")
- */
 export function formatStarCount(count: number): string {
-  if (count >= 1000000) {
-    return `${(count / 1000000).toFixed(1)}M`;
-  }
-  if (count >= 1000) {
-    return `${(count / 1000).toFixed(1)}k`;
-  }
+  if (count >= 1000000) return `${(count / 1000000).toFixed(1)}M`;
+  if (count >= 1000) return `${(count / 1000).toFixed(1)}k`;
   return count.toString();
 }
 
-/**
- * Format relative time (e.g., "2 days ago", "3 months ago")
- */
 export function formatRelativeTime(dateString: string): string {
   if (!dateString) return 'Unknown';
-  
   const date = new Date(dateString);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
   if (diffDays === 0) return 'Today';
   if (diffDays === 1) return 'Yesterday';
   if (diffDays < 7) return `${diffDays} days ago`;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,374 +1,73 @@
-import { motion, useReducedMotion } from 'framer-motion';
-import { ArrowRight, Code2, Sparkles, Globe, Layers, Palette } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { useMemo, memo } from 'react';
-import { Button } from '@/components/ui/button';
-import { useProfile, useProjects } from '@/hooks/usePortfolioData';
+import { lazy, Suspense } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useProfile, useProjects } from '@/hooks/usePortfolioData';
+import { useGitHubHighlights } from '@/hooks/useGitHubStats';
 import { useTranslations } from '@/hooks/useTranslations';
 import { useTranslatedText } from '@/hooks/useTranslatedContent';
-import { LINKS } from '@/lib/siteLinks'; // Import LINKS
+import { siteConfig } from '@/config/site';
+import { useSeoMetadata } from '@/hooks/useSeoMetadata';
 
-// Memoized project card component to prevent re-renders
-const FeaturedProjectCard = memo(({ 
-  project, 
-  index,
-  prefersReducedMotion 
-}: { 
-  project: {
-    slug: string; // Added slug to project type
-    name: string;
-    summary: string;
-    category: string;
-    url?: string | null;
-    repo_url?: string | null;
-    technologies?: Array<{ name: string }>;
-    year: number; // Ensure year is part of the project type
-  };
-  index: number;
-  prefersReducedMotion: boolean | null;
-}) => {
-  const techStack = useMemo(() => {
-    return (
-      ((project.technologies as Array<{ name: string }> | undefined)?.map((t) => t.name) ??
-        // Some legacy entries might include a `stack` array; guard to satisfy types safely
-        (("stack" in (project as object) ? (project as Record<string, unknown>).stack : undefined) as string[] | undefined) ??
-        []
-      ).slice(0, 3)
-    );
-  }, [project]);
-
-  return (
-    <motion.div
-      key={project.name}
-      initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
-      whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ delay: index * 0.1, duration: 0.5 }}
-      className="group"
-    >
-      <motion.div // Changed from <a> to <div> to wrap the Link
-        className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-        style={{ transformStyle: 'preserve-3d' }}
-        whileHover={
-          prefersReducedMotion
-            ? undefined
-            : { rotateX: -6, rotateY: 6, translateZ: 12 }
-        }
-        whileTap={prefersReducedMotion ? undefined : { scale: 0.99 }}
-        transition={{ type: 'spring', stiffness: 200, damping: 22 }}
-      >
-        <Link to={`/portfolio/${project.slug}`} className="block"> {/* Link to project detail page */}
-          <div className="rounded-2xl border border-border/70 bg-card/70 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-lg">
-            <div className="flex items-start justify-between mb-4">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/80 via-secondary/70 to-accent/70 text-white shadow-md">
-                <Code2 className="text-white" size={24} aria-hidden />
-              </div>
-              <div className="flex flex-col items-end gap-1">
-                <span className="text-xs font-medium px-3 py-1 rounded-full bg-muted text-muted-foreground">
-                  {project.category}
-                </span>
-                <span className="text-xs font-medium px-3 py-1 rounded-full border border-border/60 bg-background/70 text-muted-foreground">
-                  {project.year}
-                </span>
-              </div>
-            </div>
-            <h3 className="text-xl font-display font-bold mb-2 group-hover:text-primary transition-colors">
-              {project.name}
-            </h3>
-            <p className="text-muted-foreground mb-4 text-sm">
-              {project.summary}
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {techStack.map((tech) => (
-                <span
-                  key={tech}
-                  className="text-xs px-3 py-1 rounded-xl bg-muted/60 text-foreground/80"
-                >
-                  {tech}
-                </span>
-              ))}
-            </div>
-          </div>
-        </Link>
-      </motion.div>
-    </motion.div>
-  );
-});
-
-FeaturedProjectCard.displayName = 'FeaturedProjectCard';
+const HeroSection = lazy(() => import('@/components/sections/home/HeroSection').then((module) => ({ default: module.HeroSection })));
+const FeaturedProjectsSection = lazy(() => import('@/components/sections/home/FeaturedProjectsSection').then((module) => ({ default: module.FeaturedProjectsSection })));
+const GitHubHighlightsSection = lazy(() => import('@/components/sections/home/GitHubHighlightsSection').then((module) => ({ default: module.GitHubHighlightsSection })));
 
 export default function Home() {
-  const prefersReducedMotion = useReducedMotion();
   const { data: profile, isLoading: loadingProfile } = useProfile();
   const { data: projects, isLoading: loadingProjects } = useProjects();
+  const { data: githubHighlights, isLoading: loadingGitHub } = useGitHubHighlights();
   const t = useTranslations();
-  
-  // Translate dynamic content from cv.json
+
   const translatedBio = useTranslatedText(profile?.bio);
   const translatedHeadline = useTranslatedText(profile?.headline);
 
-  // Memoize animation variants to prevent recreation on every render
-  const containerVariants = useMemo(() => ({
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1,
-      },
-    },
-  }), []);
+  useSeoMetadata({
+    title: siteConfig.title,
+    description: siteConfig.description,
+    path: '/',
+  });
 
-  const itemVariants = useMemo(() => ({
-    hidden: { opacity: 0, y: 20 },
-    visible: { opacity: 1, y: 0 },
-  }), []);
+  const featuredProjects = (projects ?? []).slice(0, 6).map((project) => ({
+    slug: project.slug,
+    name: project.name,
+    summary: project.summary,
+    category: project.category,
+    year: project.year,
+    technologies:
+      project.technologies?.map((item: { name: string | null }) => ({ name: item.name ?? 'Stack' })) ??
+      (project.stack?.map((name: string) => ({ name })) ?? []),
+  }));
 
   return (
     <div>
-      {/* Hero Section */}
-      <section className="relative min-h-[calc(100dvh-8rem)] flex items-center justify-center overflow-hidden py-16">
-        <div className="container mx-auto px-6 relative z-10">
-          <motion.div
-            variants={containerVariants}
-            initial={prefersReducedMotion ? undefined : 'hidden'}
-            animate={prefersReducedMotion ? undefined : 'visible'}
-            className="max-w-4xl mx-auto text-center"
-          >
-            <motion.div
-              variants={itemVariants}
-              className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/60 px-4 py-2 shadow-[0_20px_35px_-25px_hsl(var(--secondary)/0.2)]"
-            >
-              <Sparkles className="w-4 h-4 text-accent" />
-              {loadingProfile ? (
-                <Skeleton className="w-24 h-4" />
-              ) : (
-                <span className="text-sm font-medium">{profile?.location}</span>
-              )}
-            </motion.div>
+      <Suspense fallback={<div className="px-6 py-16"><Skeleton className="mx-auto h-[480px] max-w-6xl rounded-3xl" /></div>}>
+        <HeroSection
+          loadingProfile={loadingProfile}
+          location={profile?.location}
+          name={profile?.name}
+          headline={translatedHeadline}
+          bio={translatedBio}
+          exploreLabel={t.home.explorePortfolio}
+          contactLabel={t.home.getInTouch}
+        />
+      </Suspense>
 
-            <motion.h1
-              variants={itemVariants}
-              className="text-5xl md:text-7xl font-display font-bold mb-6 mt-6 text-balance"
-            >
-              <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
-                {loadingProfile ? (
-                  <span
-                    className="inline-block w-40 h-10 mx-auto rounded-md bg-muted animate-pulse"
-                    aria-hidden
-                  />
-                ) : (
-                  profile?.name
-                )}
-              </span>
-            </motion.h1>
+      <Suspense fallback={<div className="px-6 py-24"><Skeleton className="mx-auto h-[420px] max-w-7xl rounded-3xl" /></div>}>
+        <FeaturedProjectsSection
+          loading={loadingProjects}
+          projects={featuredProjects}
+          title="Projetos em Destaque"
+          subtitle="Seleção de produtos, sistemas internos e experiências digitais que traduzem a visão de Marcelo Santos dentro do ecossistema Monynha."
+          ctaLabel={t.home.viewAllProjects}
+        />
+      </Suspense>
 
-            <motion.p
-              variants={itemVariants}
-              className="text-xl md:text-2xl text-muted-foreground mb-4 font-medium"
-            >
-              {loadingProfile ? (
-                <span
-                  className="inline-block w-64 h-6 mx-auto rounded-md bg-muted animate-pulse"
-                  aria-hidden
-                />
-              ) : (
-                translatedHeadline
-              )}
-            </motion.p>
-
-            <motion.p
-              variants={itemVariants}
-              className="text-lg text-muted-foreground/80 mb-12 max-w-2xl mx-auto"
-            >
-              {loadingProfile ? (
-                <span
-                  className="inline-block w-80 h-5 mx-auto rounded-md bg-muted animate-pulse"
-                  aria-hidden
-                />
-              ) : (
-                translatedBio
-              )}
-            </motion.p>
-
-            <motion.div
-              variants={itemVariants}
-              className="flex flex-col sm:flex-row gap-4 sm:gap-6 md:gap-8 justify-center items-center"
-            >
-              <Button
-                asChild
-                size="lg"
-                className="px-10 shadow-lg shadow-secondary/30 w-full sm:w-auto"
-              >
-                <Link to="/portfolio">
-                  <Code2 className="mr-2" />
-                  {t.home.explorePortfolio}
-                  <ArrowRight className="ml-2" />
-                </Link>
-              </Button>
-
-              <Button
-                asChild
-                variant="outline"
-                size="lg"
-                className="border-2 border-border/70 bg-card/60 px-10 hover:border-primary/70 hover:text-primary w-full sm:w-auto"
-              >
-                <Link to="/contact">
-                  {t.home.getInTouch}
-                </Link>
-              </Button>
-
-              {/* New button for Monynha.com */}
-              <Button
-                asChild
-                variant="secondary"
-                size="lg"
-                className="px-10 shadow-lg shadow-accent/30 w-full sm:w-auto"
-              >
-                <a href={LINKS.monynhaSite} target="_blank" rel="noopener noreferrer">
-                  <Globe className="mr-2" />
-                  Monynha Softwares
-                  <ArrowRight className="ml-2" />
-                </a>
-              </Button>
-            </motion.div>
-          </motion.div>
-        </div>
-
-        {/* Scroll indicator */}
-        <motion.div
-          initial={prefersReducedMotion ? undefined : { opacity: 0 }}
-          animate={prefersReducedMotion ? undefined : { opacity: 1 }}
-          transition={{ delay: 1, duration: 1 }}
-          className="absolute bottom-8 left-1/2 -translate-x-1/2 z-30"
-        >
-          <div className="w-6 h-10 border-2 border-muted-foreground/30 rounded-full flex items-start justify-center p-2">
-            <motion.div
-              animate={prefersReducedMotion ? undefined : { y: [0, 12, 0] }}
-              transition={prefersReducedMotion ? undefined : { duration: 1.5, repeat: Infinity }}
-              className="w-1 h-2 bg-primary rounded-full"
-            />
-          </div>
-        </motion.div>
-      </section>
-
-      {/* Featured Projects */}
-      <section className="py-24 px-6">
-        <div className="container mx-auto max-w-7xl">
-          <motion.div
-            initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
-            whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6 }}
-            className="text-center mb-16"
-          >
-            <h2 className="text-4xl md:text-5xl font-display font-bold mb-6">
-              Projetos em Destaque
-            </h2>
-            <p className="text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-              Seleção dos melhores trabalhos do ecossistema Monynha
-            </p>
-          </motion.div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 items-stretch">
-            {loadingProjects
-              ? Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-40 w-full rounded-2xl" />
-                ))
-              : (projects?.slice(0, 6).map((project, index) => (
-                  <FeaturedProjectCard
-                    key={project.name}
-                    project={project}
-                    index={index}
-                    prefersReducedMotion={prefersReducedMotion}
-                  />
-                )))}
-          </div>
-
-          <motion.div
-            initial={prefersReducedMotion ? undefined : { opacity: 0 }}
-            whileInView={prefersReducedMotion ? undefined : { opacity: 1 }}
-            viewport={{ once: true }}
-            className="text-center mt-12"
-          >
-            <Button asChild variant="outline" size="lg" className="border-border/70">
-              <Link to="/portfolio">
-                {t.home.viewAllProjects}
-                <ArrowRight className="ml-2" />
-              </Link>
-            </Button>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Collections & Art (static, no data needed) */}
-      <section className="pb-24 px-6">
-        <div className="container mx-auto">
-          <motion.div
-            initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
-            whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6 }}
-            className="mb-12 text-center"
-          >
-            <h2 className="text-4xl md:text-5xl font-display font-bold mb-4">
-              Coleções & Arte
-            </h2>
-            <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Experiências imersivas e séries experimentais que conectam tecnologia, narrativa e arte digital.
-            </p>
-          </motion.div>
-          {/* Static links, unchanged */}
-          <div className="grid gap-6 md:grid-cols-2">
-            <motion.div
-              initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
-              whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.6, delay: 0.1 }}
-            >
-              <Link
-                to="/series/creative-systems"
-                className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-              >
-                <div className="flex h-full flex-col rounded-2xl border border-border/70 bg-card/70 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-lg">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary via-primary to-accent text-white shadow-md">
-                    <Layers aria-hidden className="h-6 w-6" />
-                  </div>
-                  <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
-                    Creative Systems
-                  </h3>
-                  <p className="mt-3 text-sm text-muted-foreground/90">
-                    Coleção de trabalhos que explora IA aplicada, automação inteligente e interfaces artísticas conectadas ao laboratório Monynha.
-                  </p>
-                </div>
-              </Link>
-            </motion.div>
-            <motion.div
-              initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
-              whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.6, delay: 0.2 }}
-            >
-              <Link
-                to="/art/artleo"
-                className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-              >
-                <div className="flex h-full flex-col rounded-2xl border border-border/70 bg-card/70 p-6 shadow-md transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-lg">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-md">
-                    <Palette aria-hidden className="h-6 w-6" />
-                  </div>
-                  <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
-                    Art Leo Creative Spaces
-                  </h3>
-                  <p className="mt-3 text-sm text-muted-foreground/90">
-                    Experiência 3D com narrativas interativas e composição sonora inspirada nos espaços criativos de Leonardo Silva.
-                  </p>
-                </div>
-              </Link>
-            </motion.div>
-          </div>
-        </div>
-      </section>
+      <Suspense fallback={<div className="px-6 pb-24"><Skeleton className="mx-auto h-[360px] max-w-7xl rounded-3xl" /></div>}>
+        <GitHubHighlightsSection
+          items={githubHighlights?.items ?? []}
+          isLoading={loadingGitHub}
+          isFallback={githubHighlights?.isFallback ?? false}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from 'framer-motion';
-import { useEffect, useMemo, useState, useCallback, memo } from 'react';
+import { useMemo, useState, useCallback, memo } from 'react';
 import { useProjects, useArtworks, useSeries } from '@/hooks/usePortfolioData';
 import type { Tables as DBTables } from '@/types/database.types';
 import { Button } from '@/components/ui/button';
@@ -9,17 +9,9 @@ import SeriesCard from '@/components/SeriesCard';
 import { LoadingPortfolioGrid } from '@/components/LoadingStates';
 import { useTranslations } from '@/hooks/useTranslations';
 import { useTranslatedText } from '@/hooks/useTranslatedContent';
+import { useSeoMetadata } from '@/hooks/useSeoMetadata';
 
-// Memoized filter button component to prevent re-renders
-const FilterButton = memo(({ 
-  category, 
-  isActive, 
-  onClick 
-}: { 
-  category: string; 
-  isActive: boolean; 
-  onClick: () => void;
-}) => (
+const FilterButton = memo(({ category, isActive, onClick }: { category: string; isActive: boolean; onClick: () => void }) => (
   <Button
     variant={isActive ? 'default' : 'outline'}
     onClick={onClick}
@@ -83,16 +75,19 @@ export default function Portfolio() {
   const { data: dbArtworks, isLoading: loadingArtworks } = useArtworks();
   const { data: dbSeries, isLoading: loadingSeries } = useSeries();
 
-  // Map DB-shaped data to the UI shapes expected by the existing cards
-  type DBProject = DBTables<'projects'> & {
-    technologies?: Array<{ name: string | null; category: string | null }>;
-  };
+  useSeoMetadata({
+    title: 'Portfólio · Marcelo Santos / Monynha Softwares',
+    description: 'Projetos, arte digital, infraestrutura e produtos do ecossistema Monynha apresentados com foco em performance e escalabilidade.',
+    path: '/portfolio',
+  });
+
+  type DBProject = DBTables<'projects'> & { technologies?: Array<{ name: string | null; category: string | null }> };
   const projects = useMemo<CVProject[]>(() => {
     return (dbProjects as DBProject[] | undefined ?? []).map((p) => ({
       slug: p.slug,
       name: p.name,
       summary: p.summary,
-      stack: (p.technologies ?? []).map((t) => t?.name).filter(Boolean) as string[],
+      stack: (p.technologies ?? []).map((item) => item?.name).filter(Boolean) as string[],
       url: p.url ?? null,
       domain: p.domain ?? null,
       repoUrl: p.repo_url ?? '',
@@ -135,73 +130,24 @@ export default function Portfolio() {
     }));
   }, [dbSeries]);
 
-  useEffect(() => {
-    if (typeof document === 'undefined') return;
-
-    const previousTitle = document.title;
-    document.title = 'Portfólio · Monynha Softwares';
-
-    const descriptionSelector = 'meta[name="description"]';
-    const existingMeta = document.querySelector<HTMLMetaElement>(
-      descriptionSelector,
-    );
-    const createdMeta = !existingMeta;
-    const meta = existingMeta ?? document.createElement('meta');
-    const previousDescription = meta.getAttribute('content') ?? '';
-
-    if (!existingMeta) {
-      meta.name = 'description';
-      document.head.appendChild(meta);
-    }
-
-    meta.setAttribute(
-      'content',
-      'Portfólio oficial da Monynha Softwares com produtos digitais, iniciativas de IA, infraestrutura e experiências criativas.',
-    );
-
-    return () => {
-      document.title = previousTitle;
-      if (createdMeta && meta.parentNode) {
-        meta.parentNode.removeChild(meta);
-      } else {
-        meta.setAttribute('content', previousDescription);
-      }
-    };
-  }, []);
 
   const categories = useMemo(() => {
-    const base = [
-      t.portfolio.filterAll,
-      ...projects.map((p) => p.category),
-      t.portfolio.filterDigitalArt,
-      t.portfolio.filterCreativeSeries,
-    ];
+    const base = [t.portfolio.filterAll, ...projects.map((p) => p.category), t.portfolio.filterDigitalArt, t.portfolio.filterCreativeSeries];
     return Array.from(new Set(base));
   }, [projects, t]);
 
-  // Memoize filter change handler to prevent unnecessary re-renders
-  const handleFilterChange = useCallback((category: string) => {
-    setFilter(category);
-  }, []);
+  const handleFilterChange = useCallback((category: string) => setFilter(category), []);
 
   const filteredItems = useMemo<PortfolioEntry[]>(() => {
     let items: Array<CVProject | CVArtwork | CVSeries> = [];
-    if (filter === t.portfolio.filterAll) {
-      items = [...projects, ...artworks, ...seriesEntries];
-    } else if (filter === t.portfolio.filterDigitalArt) {
-      items = artworks;
-    } else if (filter === t.portfolio.filterCreativeSeries) {
-      items = seriesEntries;
-    } else {
-      items = projects.filter((p) => p.category === filter);
-    }
+    if (filter === t.portfolio.filterAll) items = [...projects, ...artworks, ...seriesEntries];
+    else if (filter === t.portfolio.filterDigitalArt) items = artworks;
+    else if (filter === t.portfolio.filterCreativeSeries) items = seriesEntries;
+    else items = projects.filter((p) => p.category === filter);
 
     return items.map((item) => {
-      // Check for materials property (unique to artwork)
       if ('materials' in item) return { ...item, type: 'artwork' } as PortfolioEntry;
-      // Check for works property (unique to series)
       if ('works' in item) return { ...item, type: 'series' } as PortfolioEntry;
-      // Otherwise it's a project
       return { ...item, type: 'project' } as PortfolioEntry;
     });
   }, [artworks, filter, projects, seriesEntries, t]);
@@ -213,65 +159,35 @@ export default function Portfolio() {
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="text-center mb-16"
+          className="mb-16 text-center"
         >
-          <h1 className="text-5xl md:text-6xl font-display font-bold mb-6">
-            Portfolio
-          </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-            {pageSubtitle}
-          </p>
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-secondary">Marcelo Santos / Monynha Softwares</p>
+          <h1 className="mt-4 text-5xl font-bold md:text-6xl">Portfolio</h1>
+          <p className="mx-auto mt-6 max-w-2xl text-xl leading-relaxed text-muted-foreground">{pageSubtitle}</p>
         </motion.div>
 
-        {/* Filters */}
         <motion.div
           initial={prefersReducedMotion ? undefined : { opacity: 0, y: 10 }}
           animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.5 }}
-          className="flex flex-wrap gap-3 justify-center mb-16"
+          className="mb-16 flex flex-wrap justify-center gap-3"
         >
           {categories.map((category) => (
-            <FilterButton
-              key={category}
-              category={category}
-              isActive={filter === category}
-              onClick={() => handleFilterChange(category)}
-            />
+            <FilterButton key={category} category={category} isActive={filter === category} onClick={() => handleFilterChange(category)} />
           ))}
         </motion.div>
 
-        {/* Dynamic Content Grid */}
-        {(loadingProjects || loadingArtworks || loadingSeries) ? (
+        {loadingProjects || loadingArtworks || loadingSeries ? (
           <LoadingPortfolioGrid count={6} />
         ) : (
-          <>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 items-stretch">
-              {filteredItems.map((item, index) => {
-                if (item.type === 'project') {
-                  return <ProjectCard key={`project-${item.slug}`} project={item} index={index} />;
-                }
-                if (item.type === 'artwork') {
-                  return <ArtworkCard key={`artwork-${item.slug}`} artwork={item} index={index} />;
-                }
-                if (item.type === 'series') {
-                  return <SeriesCard key={`series-${item.slug}`} series={item} index={index} />;
-                }
-                return null;
-              })}
-            </div>
-
-            {filteredItems.length === 0 && (
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="text-center py-16"
-              >
-                <p className="text-muted-foreground text-lg">
-                  Nenhum item encontrado nesta categoria.
-                </p>
-              </motion.div>
-            )}
-          </>
+          <div className="grid grid-cols-1 gap-8 items-stretch md:grid-cols-2 lg:grid-cols-3">
+            {filteredItems.map((item, index) => {
+              if (item.type === 'project') return <ProjectCard key={`project-${item.slug}`} project={item} index={index} />;
+              if (item.type === 'artwork') return <ArtworkCard key={`artwork-${item.slug}`} artwork={item} index={index} />;
+              if (item.type === 'series') return <SeriesCard key={`series-${item.slug}`} series={item} index={index} />;
+              return null;
+            })}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Melhorar performance do carregamento inicial reduzindo custo crítico e possibilitar evolução modular do produto.  
- Tornar conteúdo mais dinâmico via GitHub (GraphQL preferencial) mantendo fallback robusto para falhas/limites de API.  
- Controlar e degradar experiências 3D automaticamente em dispositivos fracos e respeitar `prefers-reduced-motion`.  
- Centralizar branding, URLs e configurações para facilitar integração com o ecossistema Monynha e evitar hardcodes espalhados.  

### Description
- Modularizei a Home em seções lazy-loaded (`src/components/sections/home/*`) e passei a carregar as seções pesadas com `Suspense` e skeletons; extraí o `Hero`, `FeaturedProjectsSection` e `GitHubHighlightsSection`.  
- Adicionei configuração central em `src/config/site.ts` e atualizei `.env.example` para flags e endpoints de GitHub/Supabase; criei `useSeoMetadata` (`src/hooks/useSeoMetadata.ts`) para gerenciar `title`, `description`, canonical, Open Graph e Twitter.  
- Introduzi um fallback estático leve `StaticBackdrop` e reescrevi `useDeviceCapabilities` para detectar capacidade do dispositivo e decidir entre o `Galaxy` 3D ou o backdrop estático; atualizei `Layout.tsx` para render condicional do background.  
- Implementei integração dinâmica com GitHub em `src/lib/githubApi.ts` (prefere GraphQL quando `VITE_GITHUB_TOKEN` está presente, fallback REST e fallback local) e hooks em `src/hooks/useGitHubStats.ts`; a seção de highlights consome esse fluxo com loading/fallback visuais.  
- Mantive os fallbacks para `cv.json` via os hooks de dados (`src/hooks/usePortfolioData.ts`) para garantir resiliência quando APIs externas falham.  
- Atualizei `index.html` com novos metadados SEO/OG/Twitter e criei/atualizei documentação operacional `TODO.md` e `AGENTS.md` com regras de performance, 3D, dados dinâmicos e checklist.  

### Testing
- Executei `npm run lint` com sucesso.  
- Executei `npm run build` com sucesso (build concluído; `vendor-three` permanece lazy-loaded e grande, conforme documentado).  
- Executei `npm run test` (Vitest): todos os testes passaram (`49` tests, `8` arquivos), porém o runner emitiu avisos `ENETUNREACH` ao tentar alcançar serviços externos de tradução no ambiente isolado, limitação de rede do ambiente que não quebrou a suite; resultado final: testes OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc69f4eb688322904a5c9ce315ef74)